### PR TITLE
enabled dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
#12 added every sub module as its own check to make and also the root project as there is a on that level as well.

Note that the branch name contains sonar-cloud but I decided to do that as its own PR later on.