### PR TITLE
improved exceptions

### DIFF
--- a/domain/src/main/java/be/xplore/githubmetrics/domain/exceptions/GenericAdapterException.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/exceptions/GenericAdapterException.java
@@ -4,4 +4,8 @@ public class GenericAdapterException extends RuntimeException {
     public GenericAdapterException(String message) {
         super(message);
     }
+
+    public GenericAdapterException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapter.java
@@ -3,14 +3,11 @@ package be.xplore.githubmetrics.githubadapter;
 import be.xplore.githubmetrics.domain.domain.Repository;
 import be.xplore.githubmetrics.domain.queries.RepositoriesQueryPort;
 import be.xplore.githubmetrics.githubadapter.config.GithubConfig;
-import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGHRepositoryArrayException;
 import be.xplore.githubmetrics.githubadapter.mappingclasses.GHRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestClientException;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -46,31 +43,23 @@ public class RepositoriesAdapter implements RepositoriesQueryPort {
     }
 
     private List<Repository> fetchRepositories(String path, Map<String, String> parameters) {
-        ResponseEntity<GHRepository[]> responseEntity = this.getEntity(
+        ResponseEntity<GHRepository[]> responseEntity = GithubAdapter.getEntity(
                 this.githubAdapter
-                        .getResponseSpec(path, parameters)
+                        .getResponseSpec(path, parameters),
+                GHRepository[].class
         );
 
         return conditionallyFetchNextPage(responseEntity);
     }
 
     private List<Repository> fetchRepositories(String fullUrl) {
-        ResponseEntity<GHRepository[]> responseEntity = this.getEntity(
+        ResponseEntity<GHRepository[]> responseEntity = GithubAdapter.getEntity(
                 this.githubAdapter
-                        .getResponseSpec(fullUrl)
+                        .getResponseSpec(fullUrl),
+                GHRepository[].class
         );
 
         return conditionallyFetchNextPage(responseEntity);
-    }
-
-    private ResponseEntity<GHRepository[]> getEntity(
-            RestClient.ResponseSpec response
-    ) {
-        try {
-            return response.toEntity(GHRepository[].class);
-        } catch (RestClientException e) {
-            throw new UnableToParseGHRepositoryArrayException(e.getMessage());
-        }
     }
 
     private List<Repository> conditionallyFetchNextPage(

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunJobsAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunJobsAdapter.java
@@ -2,7 +2,6 @@ package be.xplore.githubmetrics.githubadapter;
 
 import be.xplore.githubmetrics.domain.domain.Job;
 import be.xplore.githubmetrics.domain.queries.WorkFlowRunJobsQueryPort;
-import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGHWorkFlowRunJobsException;
 import be.xplore.githubmetrics.githubadapter.mappingclasses.GHWorkflowRunJobs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,32 +12,29 @@ import java.util.HashMap;
 import java.util.List;
 
 @Component
-public class WorkFlowRunJobsAdapter implements WorkFlowRunJobsQueryPort {
-    private static final Logger LOGGER = LoggerFactory.getLogger(WorkFlowRunJobsAdapter.class);
+public class WorkflowRunJobsAdapter implements WorkFlowRunJobsQueryPort {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowRunJobsAdapter.class);
     private final GithubAdapter githubAdapter;
 
-    public WorkFlowRunJobsAdapter(GithubAdapter githubAdapter) {
+    public WorkflowRunJobsAdapter(GithubAdapter githubAdapter) {
         this.githubAdapter = githubAdapter;
     }
 
     @Override
     public List<Job> getWorkFlowRunJobs(String repositoryName, long workflowRunId) {
         LOGGER.debug("Getting Jobs for workflow run: {}", workflowRunId);
-        var responseSpec = githubAdapter.getResponseSpec(
-                MessageFormat.format(
-                        "repos/{0}/{1}/actions/runs/{2,number,#}/jobs",
-                        this.githubAdapter.getConfig().org(),
-                        repositoryName,
-                        workflowRunId
+        var responseSpec = GithubAdapter.getBody(
+                githubAdapter.getResponseSpec(
+                        MessageFormat.format(
+                                "repos/{0}/{1}/actions/runs/{2,number,#}/jobs",
+                                this.githubAdapter.getConfig().org(),
+                                repositoryName,
+                                workflowRunId
+                        ),
+                        new HashMap<>()
                 ),
-                new HashMap<>()
-        ).body(GHWorkflowRunJobs.class);
-
-        if (responseSpec == null) {
-            throw new UnableToParseGHWorkFlowRunJobsException(
-                    "Unexpected error in parsing workflow run jobs"
-            );
-        }
+                GHWorkflowRunJobs.class
+        );
 
         List<Job> jobs = responseSpec.getJobs();
         LOGGER.debug("number of jobs for workflow run {}: {}", workflowRunId, jobs.size());

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapter.java
@@ -3,7 +3,6 @@ package be.xplore.githubmetrics.githubadapter;
 import be.xplore.githubmetrics.domain.domain.Repository;
 import be.xplore.githubmetrics.domain.domain.WorkflowRun;
 import be.xplore.githubmetrics.domain.queries.WorkflowRunsQueryPort;
-import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGHActionRunsException;
 import be.xplore.githubmetrics.githubadapter.mappingclasses.GHActionRuns;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,12 +15,12 @@ import java.util.HashMap;
 import java.util.List;
 
 @Service
-public class WorkFlowRunsAdapter implements WorkflowRunsQueryPort {
+public class WorkflowRunsAdapter implements WorkflowRunsQueryPort {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(WorkFlowRunsAdapter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowRunsAdapter.class);
     private final GithubAdapter githubAdapter;
 
-    public WorkFlowRunsAdapter(GithubAdapter githubAdapter) {
+    public WorkflowRunsAdapter(GithubAdapter githubAdapter) {
         this.githubAdapter = githubAdapter;
     }
 
@@ -34,21 +33,19 @@ public class WorkFlowRunsAdapter implements WorkflowRunsQueryPort {
                         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
         );
 
-        var responseSpec = githubAdapter.getResponseSpec(
-                MessageFormat.format(
-                        "repos/{0}/{1}/actions/runs",
-                        this.githubAdapter.getConfig().org(),
-                        repository.getName()
+        var ghWorkflowRuns = GithubAdapter.getBody(
+                githubAdapter.getResponseSpec(
+                        MessageFormat.format(
+                                "repos/{0}/{1}/actions/runs",
+                                this.githubAdapter.getConfig().org(),
+                                repository.getName()
+                        ),
+                        parameterMap
                 ),
-                parameterMap
-        ).body(GHActionRuns.class);
+                GHActionRuns.class
+        );
 
-        if (responseSpec == null) {
-            throw new UnableToParseGHActionRunsException(
-                    "Unexpected error in parsing Workflow Runs"
-            );
-        }
-        List<WorkflowRun> workflowRuns = responseSpec.getWorkFlowRuns(repository);
+        List<WorkflowRun> workflowRuns = ghWorkflowRuns.getWorkFlowRuns(repository);
         LOGGER.debug("number of unique workflow runs: {}", workflowRuns.size());
         return workflowRuns;
     }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/exceptions/UnableToParseGHActionRunsException.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/exceptions/UnableToParseGHActionRunsException.java
@@ -1,9 +1,0 @@
-package be.xplore.githubmetrics.githubadapter.exceptions;
-
-import be.xplore.githubmetrics.domain.exceptions.GenericAdapterException;
-
-public class UnableToParseGHActionRunsException extends GenericAdapterException {
-    public UnableToParseGHActionRunsException(String message) {
-        super(message);
-    }
-}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/exceptions/UnableToParseGHRepositoryArrayException.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/exceptions/UnableToParseGHRepositoryArrayException.java
@@ -1,9 +1,0 @@
-package be.xplore.githubmetrics.githubadapter.exceptions;
-
-import be.xplore.githubmetrics.domain.exceptions.GenericAdapterException;
-
-public class UnableToParseGHRepositoryArrayException extends GenericAdapterException {
-    public UnableToParseGHRepositoryArrayException(String message) {
-        super(message);
-    }
-}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/exceptions/UnableToParseGHWorkFlowRunJobsException.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/exceptions/UnableToParseGHWorkFlowRunJobsException.java
@@ -1,7 +1,0 @@
-package be.xplore.githubmetrics.githubadapter.exceptions;
-
-public class UnableToParseGHWorkFlowRunJobsException extends RuntimeException {
-    public UnableToParseGHWorkFlowRunJobsException(String message) {
-        super(message);
-    }
-}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/exceptions/UnableToParseGithubResponseException.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/exceptions/UnableToParseGithubResponseException.java
@@ -1,0 +1,13 @@
+package be.xplore.githubmetrics.githubadapter.exceptions;
+
+import be.xplore.githubmetrics.domain.exceptions.GenericAdapterException;
+
+public class UnableToParseGithubResponseException extends GenericAdapterException {
+    public UnableToParseGithubResponseException(String message) {
+        super(message);
+    }
+
+    public UnableToParseGithubResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapterTest.java
@@ -2,7 +2,7 @@ package be.xplore.githubmetrics.githubadapter;
 
 import be.xplore.githubmetrics.githubadapter.config.GithubConfig;
 import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfiguration;
-import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGHRepositoryArrayException;
+import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGithubResponseException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,7 +82,7 @@ class RepositoriesAdapterTest {
                         .withBody("invalid body")));
 
         assertThrows(
-                UnableToParseGHRepositoryArrayException.class,
+                UnableToParseGithubResponseException.class,
                 this.repositoriesAdapter::getAllRepositories
         );
     }

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunJobsAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunJobsAdapterTest.java
@@ -4,7 +4,7 @@ import be.xplore.githubmetrics.domain.domain.Job;
 import be.xplore.githubmetrics.domain.exceptions.GenericAdapterException;
 import be.xplore.githubmetrics.githubadapter.config.GithubConfig;
 import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfiguration;
-import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGHWorkFlowRunJobsException;
+import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGithubResponseException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class WorkflowRunJobsAdapterTest {
     private WireMockServer wireMockServer;
-    private WorkFlowRunJobsAdapter workFlowRunJobsAdapter;
+    private WorkflowRunJobsAdapter workFlowRunJobsAdapter;
 
     @BeforeEach
     void setupWireMock() {
@@ -39,7 +39,7 @@ class WorkflowRunJobsAdapterTest {
                 "token",
                 "github-insights"
         );
-        workFlowRunJobsAdapter = new WorkFlowRunJobsAdapter(
+        workFlowRunJobsAdapter = new WorkflowRunJobsAdapter(
                 new GithubAdapter(
                         githubConfig,
                         new GithubRestClientConfiguration().getGithubRestClient(githubConfig)
@@ -82,7 +82,7 @@ class WorkflowRunJobsAdapterTest {
                 )
         );
         assertThrows(
-                UnableToParseGHWorkFlowRunJobsException.class,
+                UnableToParseGithubResponseException.class,
                 () -> workFlowRunJobsAdapter.getWorkFlowRunJobs(
                         "github-metrics",
                         8828175949L)

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapterTest.java
@@ -4,7 +4,7 @@ import be.xplore.githubmetrics.domain.domain.Repository;
 import be.xplore.githubmetrics.domain.exceptions.GenericAdapterException;
 import be.xplore.githubmetrics.githubadapter.config.GithubConfig;
 import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfiguration;
-import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGHActionRunsException;
+import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGithubResponseException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +27,7 @@ class WorkflowRunsAdapterTest {
 
     private final Repository repository;
     private WireMockServer wireMockServer;
-    private WorkFlowRunsAdapter workflowRunsAdapter;
+    private WorkflowRunsAdapter workflowRunsAdapter;
 
     WorkflowRunsAdapterTest() {
         this.repository = new Repository(123L, "github-metrics", "", new ArrayList<>());
@@ -47,7 +47,7 @@ class WorkflowRunsAdapterTest {
                 "token",
                 "github-insights"
         );
-        workflowRunsAdapter = new WorkFlowRunsAdapter(
+        workflowRunsAdapter = new WorkflowRunsAdapter(
                 new GithubAdapter(
                         githubConfig,
                         new GithubRestClientConfiguration().getGithubRestClient(githubConfig)
@@ -90,7 +90,7 @@ class WorkflowRunsAdapterTest {
                 )
         );
         assertThrows(
-                UnableToParseGHActionRunsException.class,
+                UnableToParseGithubResponseException.class,
                 () -> workflowRunsAdapter.getLastDaysWorkflows(repository)
         );
     }


### PR DESCRIPTION
#50 added the possibility to add the throwable cause to the generic exception to give a clearer context.

Also changed the `getEntity` method on the `RepositoriesAdapter` to be on the `GithubAdapter` and made it generic since almost any adapter could use it.
Its so generic because it handles missing bodies and throws exceptions if nessesary.