### PR TITLE
#57 Move RestClient into its own bean

### DIFF
--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/GithubAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/GithubAdapter.java
@@ -14,15 +14,9 @@ public class GithubAdapter {
     private final RestClient restClient;
     private final GithubConfig config;
 
-    public GithubAdapter(GithubConfig config) {
+    public GithubAdapter(GithubConfig config, RestClient restClient) {
         this.config = config;
-        this.restClient = RestClient.builder()
-                .defaultHeaders(
-                        httpHeaders -> {
-                            httpHeaders.set("X-Github-Api-Version", "2022-11-28");
-                            httpHeaders.setBearerAuth(this.config.token());
-                        })
-                .build();
+        this.restClient = restClient;
     }
 
     public RestClient.ResponseSpec getResponseSpec(String path, Map<String, String> queryParams) {

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientConfiguration.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientConfiguration.java
@@ -1,0 +1,20 @@
+package be.xplore.githubmetrics.githubadapter.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class GithubRestClientConfiguration {
+
+    @Bean
+    public RestClient getGithubRestClient(GithubConfig githubConfig) {
+        return RestClient.builder()
+                .defaultHeaders(
+                        httpHeaders -> {
+                            httpHeaders.set("X-Github-Api-Version", "2022-11-28");
+                            httpHeaders.setBearerAuth(githubConfig.token());
+                        })
+                .build();
+    }
+}

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/GithubAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/GithubAdapterTest.java
@@ -1,10 +1,12 @@
 package be.xplore.githubmetrics.githubadapter;
 
 import be.xplore.githubmetrics.githubadapter.config.GithubConfig;
+import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfiguration;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
 
 import java.util.HashMap;
 
@@ -16,13 +18,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GithubAdapterTest {
 
-    private final GithubAdapter githubAdapter = new GithubAdapter(new GithubConfig(
+    private final GithubConfig githubConfig = new GithubConfig(
             "http",
             "localhost",
             "8081",
             "",
             "github-insights"
-    ));
+    );
+
+    private final RestClient restClient = new GithubRestClientConfiguration().getGithubRestClient(githubConfig);
+    private final GithubAdapter githubAdapter = new GithubAdapter(githubConfig, restClient);
     private WireMockServer wireMockServer;
 
     @BeforeEach

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapterTest.java
@@ -1,11 +1,13 @@
 package be.xplore.githubmetrics.githubadapter;
 
 import be.xplore.githubmetrics.githubadapter.config.GithubConfig;
+import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfiguration;
 import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGHRepositoryArrayException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -15,19 +17,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class RepositoriesAdapterTest {
+    private final GithubConfig githubConfig = new GithubConfig(
+            "http",
+            "localhost",
+            "8081",
+            "",
+            "github-insights"
+    );
 
-    private final RepositoriesAdapter repositoriesAdapter;
+    private final RestClient restClient = new GithubRestClientConfiguration().getGithubRestClient(githubConfig);
+    private final GithubAdapter githubAdapter = new GithubAdapter(githubConfig, restClient);
+    private final RepositoriesAdapter repositoriesAdapter = new RepositoriesAdapter(githubConfig, githubAdapter);
     private WireMockServer wireMockServer;
-
-    RepositoriesAdapterTest() {
-        var config = new GithubConfig(
-                "http", "localhost", "8081", "",
-                "github-insights"
-        );
-        this.repositoriesAdapter = new RepositoriesAdapter(
-                config, new GithubAdapter(config)
-        );
-    }
 
     @BeforeEach
     void setUp() {

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunJobsAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunJobsAdapterTest.java
@@ -3,6 +3,7 @@ package be.xplore.githubmetrics.githubadapter;
 import be.xplore.githubmetrics.domain.domain.Job;
 import be.xplore.githubmetrics.domain.exceptions.GenericAdapterException;
 import be.xplore.githubmetrics.githubadapter.config.GithubConfig;
+import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfiguration;
 import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGHWorkFlowRunJobsException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;
@@ -38,7 +39,11 @@ class WorkflowRunJobsAdapterTest {
                 "token",
                 "github-insights"
         );
-        workFlowRunJobsAdapter = new WorkFlowRunJobsAdapter(new GithubAdapter(githubConfig));
+        workFlowRunJobsAdapter = new WorkFlowRunJobsAdapter(
+                new GithubAdapter(
+                        githubConfig,
+                        new GithubRestClientConfiguration().getGithubRestClient(githubConfig)
+                ));
         configureFor("localhost", wireMockServer.port());
     }
 

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapterTest.java
@@ -3,6 +3,7 @@ package be.xplore.githubmetrics.githubadapter;
 import be.xplore.githubmetrics.domain.domain.Repository;
 import be.xplore.githubmetrics.domain.exceptions.GenericAdapterException;
 import be.xplore.githubmetrics.githubadapter.config.GithubConfig;
+import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfiguration;
 import be.xplore.githubmetrics.githubadapter.exceptions.UnableToParseGHActionRunsException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;
@@ -47,8 +48,10 @@ class WorkflowRunsAdapterTest {
                 "github-insights"
         );
         workflowRunsAdapter = new WorkFlowRunsAdapter(
-                new GithubAdapter(githubConfig)
-        );
+                new GithubAdapter(
+                        githubConfig,
+                        new GithubRestClientConfiguration().getGithubRestClient(githubConfig)
+                ));
         configureFor("localhost", wireMockServer.port());
     }
 


### PR DESCRIPTION
moved The RestClient configuration and build into its own configuration class and a function that builds and returns the RestClient for use