### PR TITLE
switched to virtual threads

### DIFF
--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/SchedulingConfiguration.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/SchedulingConfiguration.java
@@ -1,8 +1,11 @@
 package be.xplore.githubmetrics.prometheusexporter.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 @ConditionalOnProperty(
         value = "app.scheduling.enable", havingValue = "true", matchIfMissing = true
@@ -10,4 +13,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @Configuration
 @EnableScheduling
 public class SchedulingConfiguration {
+
+    @Bean
+    TaskScheduler taskScheduler() {
+        var scheduler = new SimpleAsyncTaskScheduler();
+        scheduler.setVirtualThreads(true);
+        return scheduler;
+    }
 }


### PR DESCRIPTION
#80 Before the MetricScheduler would have spring inject a TaskScheduler which did not use Virtual threads.

Now we provide our own SimpleAsyncTaskScheduler which is set to use Virtual threads. I have confirmed this by logging the current thread during a scheduled run.