### PR TITLE
#81 Add cache eviction back in to the system

### DIFF
--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapter.java
@@ -28,7 +28,6 @@ public class WorkflowRunsAdapter implements WorkflowRunsQueryPort {
     @Cacheable("WorkflowRuns")
     @Override
     public List<WorkflowRun> getLastDaysWorkflowRuns(Repository repository) {
-        LOGGER.error("this is getting un cached response");
         var parameterMap = new HashMap<String, String>();
         parameterMap.put(
                 "created",

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunStatusCountsOfLastDayExporter.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunStatusCountsOfLastDayExporter.java
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
 import java.util.EnumMap;
@@ -86,6 +87,7 @@ public class WorkflowRunStatusCountsOfLastDayExporter implements ScheduledExport
     }
 
     @Override
+    @CacheEvict(value = "WorkflowRuns", allEntries = true, beforeInvocation = true)
     public void run() {
         this.retrieveAndExportLastDaysWorkflowRunStatusCounts();
     }


### PR DESCRIPTION
added the @CacheEvict annotation to the run function which gets called from the scheduler in the prometheus exporter we realize this does make the caching bleed into the exporter from the GH adapter but there doesn't seem to be a way around that currently. a potential future solution to this would be have a webhook that cache evicts on say a new workflow run starting. and then this change is the easiest to refactor rather then a more in depth implementation.