### PR TITLE
#94 prefer run time dependencies if possible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,14 +56,17 @@ allprojects {
 }
 
 dependencies {
-    "implementation"(project(":domain"))
-    "implementation"(project(":github-adapter"))
-    "implementation"(project(":prometheus-exporter"))
+    "runtimeOnly"(project(":domain"))
+    "runtimeOnly"(project(":github-adapter"))
+    "runtimeOnly"(project(":prometheus-exporter"))
 
     "implementation"("org.springframework.boot:spring-boot-autoconfigure")
     "implementation"("org.springframework.boot:spring-boot")
 
 
+    "testImplementation"(project(":domain"))
+    "testImplementation"(project(":prometheus-exporter"))
+    "testImplementation"(project(":github-adapter"))
     "testImplementation"("org.springframework.boot:spring-boot-starter-web")
     "testImplementation"("org.springframework.boot:spring-boot-starter-test")
     "testImplementation"("org.wiremock:wiremock-jetty12:$wiremockVersion")

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubAdapterConfig.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubAdapterConfig.java
@@ -1,0 +1,9 @@
+package be.xplore.githubmetrics.githubadapter.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({GithubProperties.class})
+public class GithubAdapterConfig {
+}

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/MetricScheduler.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/MetricScheduler.java
@@ -19,6 +19,8 @@ import java.util.concurrent.ScheduledFuture;
         value = "app.scheduling.enable", havingValue = "true", matchIfMissing = true
 )
 @Service
+
+
 public class MetricScheduler implements SchedulingConfigurer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetricScheduler.class);

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/PrometheusExporterConfig.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/PrometheusExporterConfig.java
@@ -1,0 +1,9 @@
+package be.xplore.githubmetrics.prometheusexporter.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({SchedulingProperties.class})
+public class PrometheusExporterConfig {
+}

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/SchedulingProperties.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/SchedulingProperties.java
@@ -1,4 +1,4 @@
-package be.xplore.githubmetrics.prometheusexporter;
+package be.xplore.githubmetrics.prometheusexporter.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/job/JobsLabelCountsOfLastDayExporter.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/job/JobsLabelCountsOfLastDayExporter.java
@@ -5,7 +5,7 @@ import be.xplore.githubmetrics.domain.job.model.Job;
 import be.xplore.githubmetrics.domain.job.model.JobConclusion;
 import be.xplore.githubmetrics.domain.job.model.JobStatus;
 import be.xplore.githubmetrics.prometheusexporter.ScheduledExporter;
-import be.xplore.githubmetrics.prometheusexporter.SchedulingProperties;
+import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunStatusCountsOfLastDayExporter.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunStatusCountsOfLastDayExporter.java
@@ -4,7 +4,7 @@ import be.xplore.githubmetrics.domain.workflowrun.GetAllWorkflowRunsOfLastDayUse
 import be.xplore.githubmetrics.domain.workflowrun.model.WorkflowRun;
 import be.xplore.githubmetrics.domain.workflowrun.model.WorkflowRunStatus;
 import be.xplore.githubmetrics.prometheusexporter.ScheduledExporter;
-import be.xplore.githubmetrics.prometheusexporter.SchedulingProperties;
+import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;

--- a/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/job/JobsLabelCountsOfLastDayExporterTest.java
+++ b/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/job/JobsLabelCountsOfLastDayExporterTest.java
@@ -4,7 +4,7 @@ import be.xplore.githubmetrics.domain.job.GetAllJobsOfLastDayUseCase;
 import be.xplore.githubmetrics.domain.job.model.Job;
 import be.xplore.githubmetrics.domain.job.model.JobConclusion;
 import be.xplore.githubmetrics.domain.job.model.JobStatus;
-import be.xplore.githubmetrics.prometheusexporter.SchedulingProperties;
+import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;

--- a/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunStatusCountsOfLastDayExporterTest.java
+++ b/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunStatusCountsOfLastDayExporterTest.java
@@ -3,7 +3,7 @@ package be.xplore.githubmetrics.prometheusexporter.workflowrun;
 import be.xplore.githubmetrics.domain.workflowrun.GetAllWorkflowRunsOfLastDayUseCase;
 import be.xplore.githubmetrics.domain.workflowrun.model.WorkflowRun;
 import be.xplore.githubmetrics.domain.workflowrun.model.WorkflowRunStatus;
-import be.xplore.githubmetrics.prometheusexporter.SchedulingProperties;
+import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/main/java/be/xplore/githubmetrics/GithubMetrics.java
+++ b/src/main/java/be/xplore/githubmetrics/GithubMetrics.java
@@ -1,13 +1,9 @@
 package be.xplore.githubmetrics;
 
-import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
-import be.xplore.githubmetrics.prometheusexporter.SchedulingProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties({GithubProperties.class, SchedulingProperties.class})
 public class GithubMetrics {
 
     public static void main(String[] args) {


### PR DESCRIPTION
updated the dependencies in the spring app to runtime if possible but had to add some testImplementations as well to ensure that the integration tests that are on the root module still work.