### PR TITLE
added dynamic ports to integration tests

### DIFF
--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/JobsAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/JobsAdapterTest.java
@@ -8,8 +8,8 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JobsAdapterTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(JobsAdapterTest.class);
     private final WorkflowRun workflowRun = new WorkflowRun(
             8_828_175_949L,
             "Workflow Run",
@@ -44,7 +43,6 @@ class JobsAdapterTest {
         var githubProperties = TestUtility.getNoAuthGithubProperties(wireMockServer.port());
         var tokenRestClient = TestUtility.getDefaultRestClientNoAuth(githubProperties);
         jobsAdapter = new JobsAdapter(githubProperties, tokenRestClient);
-        LOGGER.info("");
     }
 
     @AfterEach
@@ -59,7 +57,7 @@ class JobsAdapterTest {
                         "/repos/github-insights/github-metrics/actions/runs/8828175949/jobs")
                 ).willReturn(
                         aResponse()
-                                .withHeader("Content-Type", "application/json")
+                                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                                 .withBodyFile("WorkFlowRunJobsValidTestData.json")
                 ));
 
@@ -75,7 +73,7 @@ class JobsAdapterTest {
                         "/repos/github-insights/github-metrics/actions/runs/8828175949/jobs"
                 )).willReturn(
                         aResponse()
-                                .withHeader("Content-Type", "application/json")
+                                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                                 .withBody("")
                 )
         );

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapterTest.java
@@ -10,11 +10,9 @@ import org.springframework.web.client.RestClientException;
 
 import java.io.IOException;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -25,11 +23,7 @@ class RepositoriesAdapterTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        wireMockServer = new WireMockServer(
-                wireMockConfig().dynamicPort()
-        );
-
-        wireMockServer.start();
+        wireMockServer = TestUtility.getWireMockServer();
         var githubProperties = TestUtility.getNoAuthGithubProperties(wireMockServer.port());
         var restClient = TestUtility.getDefaultRestClientNoAuth(githubProperties);
 
@@ -38,7 +32,6 @@ class RepositoriesAdapterTest {
                 restClient
         );
 
-        configureFor("localhost", wireMockServer.port());
     }
 
     @AfterEach

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapterTest.java
@@ -7,17 +7,17 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,17 +31,13 @@ class WorkflowRunsAdapterTest {
     @BeforeEach
     void setupWireMock() throws IOException {
 
-        this.wireMockServer = new WireMockServer(
-                wireMockConfig().dynamicPort()
-        );
-        wireMockServer.start();
+        this.wireMockServer = TestUtility.getWireMockServer();
         var githubProperties = TestUtility.getNoAuthGithubProperties(wireMockServer.port());
         var restClient = TestUtility.getDefaultRestClientNoAuth(githubProperties);
         workflowRunsAdapter = new WorkflowRunsAdapter(
                 githubProperties,
                 restClient
         );
-        configureFor("localhost", wireMockServer.port());
     }
 
     @AfterEach
@@ -56,7 +52,7 @@ class WorkflowRunsAdapterTest {
                         "/repos/github-insights/github-metrics/actions/runs?created=%3E%3D" + TestUtility.yesterday()))
                         .willReturn(
                                 aResponse()
-                                        .withHeader("Content-Type", "application/json")
+                                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                                         .withBodyFile("WorkFlowRunsValidTestData.json")
                         )
         );
@@ -71,7 +67,7 @@ class WorkflowRunsAdapterTest {
         stubFor(get(urlEqualTo("/repos/github-insights/github-metrics/actions/runs?created=%3E%3D" + TestUtility.yesterday()))
                 .willReturn(
                         aResponse()
-                                .withHeader("Content-Type", "application/json")
+                                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                                 .withBody("")
                 )
         );
@@ -86,7 +82,7 @@ class WorkflowRunsAdapterTest {
         stubFor(get(urlEqualTo("/repos/github-insights/github-metrics/actions/runs?created=%3E%3D" + TestUtility.yesterday()))
                 .willReturn(
                         aResponse()
-                                .withHeader("Content-Type", "application/json")
+                                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                                 .withBodyFile("WorkFlowRunsStatusTestData.json")
                 )
         );

--- a/src/test/java/be/xplore/githubmetrics/TestUtility.java
+++ b/src/test/java/be/xplore/githubmetrics/TestUtility.java
@@ -1,11 +1,34 @@
 package be.xplore.githubmetrics;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
 public class TestUtility {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestUtility.class);
+
     public static String yesterday() {
         return LocalDate.now().minusDays(1)
                 .format(DateTimeFormatter.ISO_LOCAL_DATE);
+    }
+
+    public static WireMockServer getWireMockServer() {
+        var wireMockServer = new WireMockServer(
+                wireMockConfig().dynamicPort()
+        );
+        wireMockServer.start();
+        configureFor("localhost", wireMockServer.port());
+        LOGGER.info(
+                "Wiremock Server running on {}.",
+                wireMockServer.baseUrl()
+        );
+        return wireMockServer;
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -22,7 +22,7 @@ app:
         workflowrunsinterval: "30 */5 * * * ?"
         jobsinterval: "0 */1 * * * ?"
     github:
-        url: http://localhost:8081
+        url: ${APP_GITHUB_URL:http://localhost:8081}
         org: "github-insights"
         application:
             id: "882159"


### PR DESCRIPTION
#59 by setting up wiremock in the @BeforeAll function we can now define the port for wiremock in a static context and thus before the environment is properly setup. This allows us to set Environemnt variables which are then picked up by the SpringBootContext and used correctly.