### PR TITLE
added pagination function

### DIFF
--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/GithubApiUtilities.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/GithubApiUtilities.java
@@ -1,0 +1,107 @@
+package be.xplore.githubmetrics.githubadapter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriBuilder;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+@Component
+public class GithubApiUtilities {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GithubApiUtilities.class);
+    private final RestClient restClient;
+
+    public GithubApiUtilities(@Qualifier("defaultRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public Function<UriBuilder, URI> setPathAndParameters(
+            String path,
+            Map<String, String> parameters
+    ) {
+        return uriBuilder -> {
+            uriBuilder.path(path);
+            for (final var parameter : parameters.entrySet()) {
+                uriBuilder.queryParam(parameter.getKey(), parameter.getValue());
+            }
+            return uriBuilder.build();
+        };
+    }
+
+    public <D, A> List<D> followPaginationLink(
+            ResponseEntity<A> responseEntity,
+            Function<A, List<D>> conversionFunction,
+            Class<A> clazz
+    ) {
+        List<D> objects = new ArrayList<>(conversionFunction.apply(
+                responseEntity.getBody()
+        ));
+
+        return getNextPageLink(responseEntity.getHeaders()).map(link -> {
+            LOGGER.trace("Parsed link was: {}", link);
+
+            List<D> nextObjects = this.followPaginationLink(
+                    getNextResponseEntity(link, clazz),
+                    conversionFunction,
+                    clazz
+            );
+
+            LOGGER.trace(
+                    "Adding {} objects to already present {} objects.",
+                    nextObjects.size(),
+                    objects.size()
+            );
+            objects.addAll(nextObjects);
+            return objects;
+        }).orElse(objects);
+
+    }
+
+    private <A> ResponseEntity<A> getNextResponseEntity(
+            String link,
+            Class<A> clazz
+    ) {
+        return this.restClient.get()
+                .uri(link)
+                .retrieve()
+                .toEntity(clazz);
+    }
+
+    private Optional<String> getNextPageLink(HttpHeaders headers) {
+        return Optional.ofNullable(headers.get("link")).flatMap(headerList -> {
+            LOGGER.trace("Valid link header is present.");
+            var headersConcatenated = String.join(" ", headerList);
+            var partsWithNext = Arrays.stream(headersConcatenated.split(","))
+                    .filter(part -> part.contains("rel=\"next\""))
+                    .toList();
+
+            Optional<String> nextPageLink = Optional.empty();
+            if (!partsWithNext.isEmpty()) {
+                nextPageLink = parseLinkOutOfHeader(partsWithNext.getFirst());
+            }
+            return nextPageLink;
+        });
+    }
+
+    private Optional<String> parseLinkOutOfHeader(String partWithNext) {
+        return Arrays.stream(partWithNext.split(";"))
+                .findFirst()
+                .map(bracedLink -> {
+                    LOGGER.trace("Parsed link before final cleanup is: {}", bracedLink);
+                    var trimmedLink = bracedLink.trim();
+                    return trimmedLink.substring(1, trimmedLink.length() - 1);
+                });
+    }
+}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunBuildTimesAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunBuildTimesAdapter.java
@@ -27,15 +27,6 @@ public class WorkflowRunBuildTimesAdapter implements WorkflowRunBuildTimesQueryP
         this.restClient = restClient;
     }
 
-    private String getBuildTimesApiPath(WorkflowRun workflowRun) {
-        return MessageFormat.format(
-                "repos/{0}/{1}/actions/runs/{2,number,#}/timing",
-                this.githubProperties.org(),
-                workflowRun.getRepository().getName(),
-                workflowRun.getId()
-        );
-    }
-
     @Cacheable("WorkflowRunBuildTimes")
     @Override
     public int getWorkflowRunBuildTimes(WorkflowRun workflowRun) {
@@ -57,5 +48,14 @@ public class WorkflowRunBuildTimesAdapter implements WorkflowRunBuildTimesQueryP
         );
 
         return buildTime;
+    }
+
+    private String getBuildTimesApiPath(WorkflowRun workflowRun) {
+        return MessageFormat.format(
+                "repos/{0}/{1}/actions/runs/{2,number,#}/timing",
+                this.githubProperties.org(),
+                workflowRun.getRepository().getName(),
+                workflowRun.getId()
+        );
     }
 }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/DebugInterceptor.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/DebugInterceptor.java
@@ -1,4 +1,4 @@
-package be.xplore.githubmetrics.githubadapter.config.auth;
+package be.xplore.githubmetrics.githubadapter.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,21 +26,23 @@ public class DebugInterceptor implements ClientHttpRequestInterceptor {
                 request.getURI(),
                 response.getStatusCode()
         );
-
-        Optional.ofNullable(response.getHeaders().get("X-RateLimit-Remaining")).ifPresent(header ->
-                Optional.ofNullable(header.getFirst()).ifPresent(rateRemaining -> {
-                    var intRateRemaining = Integer.parseInt(rateRemaining);
-                    if (intRateRemaining < 500 && intRateRemaining % 10 == 0) {
-                        LOGGER.warn("Current rate remaining is {}", intRateRemaining);
-                    }
-                    if (intRateRemaining % 500 == 0) {
-                        LOGGER.info("Current rate remaining is {}.", intRateRemaining);
-                    } else if (intRateRemaining % 100 == 0) {
-                        LOGGER.debug("Current rate remaining is {}.", intRateRemaining);
-                    }
-
-                })
+        LOGGER.trace(
+                "Headers of response were {}.",
+                response.getHeaders()
         );
+
+        Optional.ofNullable(response.getHeaders().get("X-RateLimit-Remaining")).flatMap(header -> Optional.ofNullable(header.getFirst())).ifPresent(rateRemaining -> {
+            var intRateRemaining = Integer.parseInt(rateRemaining);
+            if (intRateRemaining < 500 && intRateRemaining % 50 == 0) {
+                LOGGER.error("Current rate remaining is {}", intRateRemaining);
+            }
+            if (intRateRemaining % 500 == 0) {
+                LOGGER.info("Current rate remaining is {}.", intRateRemaining);
+            } else if (intRateRemaining % 100 == 0) {
+                LOGGER.debug("Current rate remaining is {}.", intRateRemaining);
+            }
+
+        });
         return response;
     }
 }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientConfig.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientConfig.java
@@ -1,6 +1,5 @@
 package be.xplore.githubmetrics.githubadapter.config;
 
-import be.xplore.githubmetrics.githubadapter.config.auth.DebugInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubAuthTokenInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubJwtTokenInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubUnauthorizedInterceptor;
@@ -15,7 +14,10 @@ public class GithubRestClientConfig {
     private final GithubUnauthorizedInterceptor unauthorizedInterceptor;
     private final DebugInterceptor debugInterceptor;
 
-    public GithubRestClientConfig(GithubUnauthorizedInterceptor unauthorizedInterceptor, DebugInterceptor debugInterceptor) {
+    public GithubRestClientConfig(
+            GithubUnauthorizedInterceptor unauthorizedInterceptor,
+            DebugInterceptor debugInterceptor
+    ) {
         this.unauthorizedInterceptor = unauthorizedInterceptor;
         this.debugInterceptor = debugInterceptor;
     }
@@ -35,8 +37,8 @@ public class GithubRestClientConfig {
                 )
                 .defaultStatusHandler(HttpStatusCode::is4xxClientError, this.unauthorizedInterceptor)
                 .requestInterceptors(interceptors -> {
-                    interceptors.add(githubAuthTokenInterceptor);
                     interceptors.add(debugInterceptor);
+                    interceptors.add(githubAuthTokenInterceptor);
                 })
                 .build();
     }
@@ -56,8 +58,8 @@ public class GithubRestClientConfig {
                 )
                 .defaultStatusHandler(HttpStatusCode::is4xxClientError, this.unauthorizedInterceptor)
                 .requestInterceptors(interceptors -> {
-                    interceptors.add(githubJwtTokenInterceptor);
                     interceptors.add(debugInterceptor);
+                    interceptors.add(githubJwtTokenInterceptor);
                 })
                 .build();
     }

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/JobsAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/JobsAdapterTest.java
@@ -42,7 +42,8 @@ class JobsAdapterTest {
 
         var githubProperties = TestUtility.getNoAuthGithubProperties(wireMockServer.port());
         var tokenRestClient = TestUtility.getDefaultRestClientNoAuth(githubProperties);
-        jobsAdapter = new JobsAdapter(githubProperties, tokenRestClient);
+        var utilities = new GithubApiUtilities(tokenRestClient);
+        jobsAdapter = new JobsAdapter(githubProperties, tokenRestClient, utilities);
     }
 
     @AfterEach
@@ -54,7 +55,7 @@ class JobsAdapterTest {
     void workflowRunJobsAdapterShouldReturnCorrectNumberOfJobs() {
         stubFor(
                 get(urlEqualTo(
-                        "/repos/github-insights/github-metrics/actions/runs/8828175949/jobs")
+                        "/repos/github-insights/github-metrics/actions/runs/8828175949/jobs?per_page=100")
                 ).willReturn(
                         aResponse()
                                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -70,7 +71,7 @@ class JobsAdapterTest {
     void assertExceptionWhenWorkFlowRunJobsReceivesInvalidResponseTest() {
         stubFor(
                 get(urlEqualTo(
-                        "/repos/github-insights/github-metrics/actions/runs/8828175949/jobs"
+                        "/repos/github-insights/github-metrics/actions/runs/8828175949/jobs?per_page=100"
                 )).willReturn(
                         aResponse()
                                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapterTest.java
@@ -8,8 +8,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.client.RestClientException;
 
-import java.io.IOException;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -22,14 +20,16 @@ class RepositoriesAdapterTest {
     private RepositoriesAdapter repositoriesAdapter;
 
     @BeforeEach
-    void setUp() throws IOException {
+    void setUp() {
         wireMockServer = TestUtility.getWireMockServer();
         var githubProperties = TestUtility.getNoAuthGithubProperties(wireMockServer.port());
         var restClient = TestUtility.getDefaultRestClientNoAuth(githubProperties);
+        var utilities = new GithubApiUtilities(restClient);
 
         repositoriesAdapter = new RepositoriesAdapter(
                 githubProperties,
-                restClient
+                restClient,
+                utilities
         );
 
     }

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/TestUtility.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/TestUtility.java
@@ -1,8 +1,8 @@
 package be.xplore.githubmetrics.githubadapter;
 
+import be.xplore.githubmetrics.githubadapter.config.DebugInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
 import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfig;
-import be.xplore.githubmetrics.githubadapter.config.auth.DebugInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubAuthTokenInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubJwtTokenInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubUnauthorizedInterceptor;

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapterTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,14 +28,16 @@ class WorkflowRunsAdapterTest {
     private WorkflowRunsAdapter workflowRunsAdapter;
 
     @BeforeEach
-    void setupWireMock() throws IOException {
+    void setupWireMock() {
 
         this.wireMockServer = TestUtility.getWireMockServer();
         var githubProperties = TestUtility.getNoAuthGithubProperties(wireMockServer.port());
         var restClient = TestUtility.getDefaultRestClientNoAuth(githubProperties);
+        var utilities = new GithubApiUtilities(restClient);
         workflowRunsAdapter = new WorkflowRunsAdapter(
                 githubProperties,
-                restClient
+                restClient,
+                utilities
         );
     }
 

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/auth/GithubUnauthorizedInterceptorTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/auth/GithubUnauthorizedInterceptorTest.java
@@ -1,8 +1,8 @@
 package be.xplore.githubmetrics.githubadapter.auth;
 
 import be.xplore.githubmetrics.githubadapter.TestUtility;
+import be.xplore.githubmetrics.githubadapter.config.DebugInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
-import be.xplore.githubmetrics.githubadapter.config.auth.DebugInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubUnauthorizedInterceptor;
 import be.xplore.githubmetrics.githubadapter.exceptions.GithubRequestWasUnauthenticatedException;
 import com.github.tomakehurst.wiremock.WireMockServer;

--- a/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/job/JobsLabelCountsOfLastDayExporterTest.java
+++ b/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/job/JobsLabelCountsOfLastDayExporterTest.java
@@ -13,7 +13,6 @@ import org.mockito.Mockito;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -60,7 +59,7 @@ class JobsLabelCountsOfLastDayExporterTest {
                                 getJobs(JobStatus.IN_PROGRESS, JobConclusion.SUCCESS, 8),
                                 getJobs(JobStatus.PENDING, JobConclusion.SUCCESS, 9)
                         ).flatMap(Collection::stream)
-                        .collect(Collectors.toList())
+                        .toList()
         );
 
         jobsLabelCountsOfLastDayExporter.run();

--- a/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunStatusCountsOfLastDayExporterTest.java
+++ b/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunStatusCountsOfLastDayExporterTest.java
@@ -12,7 +12,6 @@ import org.mockito.Mockito;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -50,7 +49,7 @@ class WorkflowRunStatusCountsOfLastDayExporterTest {
                                 getRuns(WorkflowRunStatus.PENDING, 3),
                                 getRuns(WorkflowRunStatus.FAILED, 7)
                         ).flatMap(Collection::stream)
-                        .collect(Collectors.toList())
+                        .toList()
         );
 
         workflowRunStatusCountsOfLastDayExporter.run();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 logging:
     level:
-        be.xplore.githubmetrics: ${DEBUG_LEVEL:INFO}
+        be.xplore.githubmetrics: ${LOGGING_LEVEL:INFO}
 management:
     endpoints:
         web:

--- a/src/test/java/be/xplore/githubmetrics/IntegrationTests.java
+++ b/src/test/java/be/xplore/githubmetrics/IntegrationTests.java
@@ -87,11 +87,11 @@ class IntegrationTests {
     }
 
     private void stubForJobsTests() {
-        stubFor(WireMock.get("/repos/github-insights/github-metrics/actions/runs/8784314559/jobs")
+        stubFor(WireMock.get("/repos/github-insights/github-metrics/actions/runs/8784314559/jobs?per_page=100")
                 .willReturn(ok()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .withBodyFile("JobsValidTestData.json")));
-        stubFor(WireMock.get("/repos/github-insights/github-metrics/actions/runs/8784267977/jobs")
+        stubFor(WireMock.get("/repos/github-insights/github-metrics/actions/runs/8784267977/jobs?per_page=100")
                 .willReturn(ok()
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .withBodyFile("JobsValidTestData.json")));


### PR DESCRIPTION
#110 Created a generic pagination function that allows for very easy pagination of any different request. The idea is that any reqest to an api endpoint will return some mappingclass which can be mapped to a list of domain objects. The generic function I created takes in this function, the initial response entity and then follows the pagination as far as it can and collects all the responses into one big list of domain objects.

Consider that this pagination functionality will have to be reworked once #112 is beeing implemented as this functionality will follow the pagination blindly until the end.