### PR TITLE
self hosted runners metric

### DIFF
--- a/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/GetAllSelfHostedRunnersUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/GetAllSelfHostedRunnersUseCase.java
@@ -1,0 +1,25 @@
+package be.xplore.githubmetrics.domain.selfhostedrunner;
+
+import be.xplore.githubmetrics.domain.repository.RepositoriesQueryPort;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class GetAllSelfHostedRunnersUseCase {
+    private final RepositoriesQueryPort repositoriesQuery;
+    private final SelfHostedRunnersQueryPort selfHostedRunnersQueryPort;
+
+    public GetAllSelfHostedRunnersUseCase(
+            RepositoriesQueryPort repositoriesQuery,
+            SelfHostedRunnersQueryPort selfHostedRunnersQueryPort
+    ) {
+        this.repositoriesQuery = repositoriesQuery;
+        this.selfHostedRunnersQueryPort = selfHostedRunnersQueryPort;
+    }
+
+    public List<SelfHostedRunner> getAllSelfHostedRunners() {
+        var repositories = this.repositoriesQuery.getAllRepositories();
+        return this.selfHostedRunnersQueryPort.getAllSelfHostedRunners(repositories);
+    }
+}

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/OperatingSystem.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/OperatingSystem.java
@@ -1,0 +1,5 @@
+package be.xplore.githubmetrics.domain.selfhostedrunner;
+
+public enum OperatingSystem {
+    MAC_OS, LINUX, WINDOWS
+}

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/SelfHostedRunner.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/SelfHostedRunner.java
@@ -1,0 +1,19 @@
+package be.xplore.githubmetrics.domain.selfhostedrunner;
+
+public class SelfHostedRunner {
+    private final OperatingSystem operatingSystem;
+    private final SelfHostedRunnerStatus selfHostedRunnerStatus;
+
+    public SelfHostedRunner(OperatingSystem operatingSystem, SelfHostedRunnerStatus selfHostedRunnerStatus) {
+        this.operatingSystem = operatingSystem;
+        this.selfHostedRunnerStatus = selfHostedRunnerStatus;
+    }
+
+    public OperatingSystem getOperatingSystem() {
+        return operatingSystem;
+    }
+
+    public SelfHostedRunnerStatus getSelfHostedRunnerStatus() {
+        return selfHostedRunnerStatus;
+    }
+}

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/SelfHostedRunnerStatus.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/SelfHostedRunnerStatus.java
@@ -1,0 +1,5 @@
+package be.xplore.githubmetrics.domain.selfhostedrunner;
+
+public enum SelfHostedRunnerStatus {
+    OFFLINE, IDLE, BUSY
+}

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/SelfHostedRunnersQueryPort.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/SelfHostedRunnersQueryPort.java
@@ -1,0 +1,9 @@
+package be.xplore.githubmetrics.domain.selfhostedrunner;
+
+import be.xplore.githubmetrics.domain.repository.Repository;
+
+import java.util.List;
+
+public interface SelfHostedRunnersQueryPort {
+    List<SelfHostedRunner> getAllSelfHostedRunners(List<Repository> repositories);
+}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/SelfHostedRunnerAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/SelfHostedRunnerAdapter.java
@@ -1,0 +1,96 @@
+package be.xplore.githubmetrics.githubadapter;
+
+import be.xplore.githubmetrics.domain.repository.Repository;
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunner;
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunnersQueryPort;
+import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
+import be.xplore.githubmetrics.githubadapter.mappingclasses.GHSelfHostedRunners;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Service
+public class SelfHostedRunnerAdapter implements SelfHostedRunnersQueryPort {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SelfHostedRunnerAdapter.class);
+    private final GithubProperties githubProperties;
+    private final RestClient restClient;
+    private final GithubApiUtilities utilities;
+
+    public SelfHostedRunnerAdapter(
+            GithubProperties githubProperties,
+            @Qualifier("defaultRestClient") RestClient restClient,
+            GithubApiUtilities utilities) {
+        this.githubProperties = githubProperties;
+        this.restClient = restClient;
+        this.utilities = utilities;
+    }
+
+    @Override
+    public List<SelfHostedRunner> getAllSelfHostedRunners(List<Repository> repositories) {
+        var organizationRunners = this.getForOrganization();
+        var repositoryRunners = this.getForRepositories(repositories);
+        return Stream.concat(organizationRunners.stream(), repositoryRunners.stream()).toList();
+    }
+
+    private List<SelfHostedRunner> getForOrganization() {
+        LOGGER.info("Fetching fresh SelfHostedRunners for Organization.");
+        var selfHostedRunners = this.fetchSelfHostedRunners(MessageFormat.format(
+                "orgs/{0}/actions/runners",
+                this.githubProperties.org()
+        ));
+        LOGGER.debug(
+                "Response for the SelfHostedRunner fetch of Organization returned {} SelfHostedRunners.",
+                selfHostedRunners.size()
+        );
+
+        return selfHostedRunners;
+    }
+
+    private List<SelfHostedRunner> getForRepositories(List<Repository> repositories) {
+        return repositories.stream().map(this::getForRepository).flatMap(List::stream).toList();
+    }
+
+    private List<SelfHostedRunner> getForRepository(Repository repository) {
+        LOGGER.info("Fetching fresh SelfHostedRunners for Repository {}.", repository.getName());
+        var selfHostedRunners = this.fetchSelfHostedRunners(MessageFormat.format(
+                "repos/{0}/{1}/actions/runners",
+                this.githubProperties.org(),
+                repository.getName()
+        ));
+        LOGGER.debug(
+                "Response for the SelfHostedRunner fetch of Repository {} returned {} SelfHostedRunners.",
+                repository.getName(),
+                selfHostedRunners.size()
+        );
+
+        return selfHostedRunners;
+    }
+
+    private List<SelfHostedRunner> fetchSelfHostedRunners(
+            String link
+    ) {
+        var parameters = new HashMap<String, String>();
+        parameters.put("per_page", "100");
+        ResponseEntity<GHSelfHostedRunners> responseEntity = this.restClient.get()
+                .uri(utilities.setPathAndParameters(
+                        link, parameters
+                ))
+                .retrieve()
+                .toEntity(GHSelfHostedRunners.class);
+
+        return this.utilities.followPaginationLink(
+                responseEntity,
+                GHSelfHostedRunners::getRunners,
+                GHSelfHostedRunners.class
+        );
+    }
+}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/WorkflowRunsAdapter.java
@@ -50,12 +50,12 @@ public class WorkflowRunsAdapter implements WorkflowRunsQueryPort {
     public List<WorkflowRun> getLastDaysWorkflowRuns(Repository repository) {
         LOGGER.info("Fetching fresh WorkflowRuns for Repository {}.", repository.getId());
         var parameters = new HashMap<String, String>();
+        parameters.put("per_page", "100");
         parameters.put(
                 "created",
                 ">=" + LocalDate.now().minusDays(1)
                         .format(DateTimeFormatter.ISO_LOCAL_DATE)
         );
-        parameters.put("per_page", "100");
 
         ResponseEntity<GHActionRuns> responseEntity = this.restClient.get()
                 .uri(utilities.setPathAndParameters(

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunner.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunner.java
@@ -1,0 +1,46 @@
+package be.xplore.githubmetrics.githubadapter.mappingclasses;
+
+import be.xplore.githubmetrics.domain.selfhostedrunner.OperatingSystem;
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunner;
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunnerStatus;
+
+import java.text.MessageFormat;
+
+public record GHSelfHostedRunner(
+        String os,
+        String status,
+        boolean busy
+) {
+    public SelfHostedRunner getRunner() {
+        return new SelfHostedRunner(this.getOs(), this.getStatus());
+    }
+
+    private OperatingSystem getOs() {
+        return switch (this.os) {
+            case "linux" -> OperatingSystem.LINUX;
+            case "windows" -> OperatingSystem.WINDOWS;
+            case "macOS" -> OperatingSystem.MAC_OS;
+            default -> throw new IllegalStateException(MessageFormat.format(
+                    "The string {0} could not be parsed to the OperatingSystem enum.",
+                    this.os
+            ));
+        };
+    }
+
+    private SelfHostedRunnerStatus getStatus() {
+        return switch (this.status) {
+            case "offline" -> SelfHostedRunnerStatus.OFFLINE;
+            case "online" -> {
+                if (this.busy) {
+                    yield SelfHostedRunnerStatus.BUSY;
+                } else {
+                    yield SelfHostedRunnerStatus.IDLE;
+                }
+            }
+            default -> throw new IllegalStateException(MessageFormat.format(
+                    "The status {0} is not one of (online, offline), meaning it cant be parsed to a SelfHostedRunnerStatus.",
+                    this.status
+            ));
+        };
+    }
+}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunners.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunners.java
@@ -1,0 +1,14 @@
+package be.xplore.githubmetrics.githubadapter.mappingclasses;
+
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunner;
+
+import java.util.List;
+
+public record GHSelfHostedRunners(
+        long total_count,
+        List<GHSelfHostedRunner> runners
+) {
+    public List<SelfHostedRunner> getRunners() {
+        return this.runners.stream().map(GHSelfHostedRunner::getRunner).toList();
+    }
+}

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunnerTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunnerTest.java
@@ -1,0 +1,67 @@
+package be.xplore.githubmetrics.githubadapter.mappingclasses;
+
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunnerStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GHSelfHostedRunnerTest {
+    private static final String LINUX = "linux";
+    private static final String ONLINE = "online";
+    private static final String OFFLINE = "offline";
+
+    @Test
+    void onlineAndBusyShouldLeadToBusyRunner() {
+        var ghRunner = new GHSelfHostedRunner(LINUX, ONLINE, true);
+        assertEquals(
+                SelfHostedRunnerStatus.BUSY,
+                ghRunner.getRunner().getSelfHostedRunnerStatus()
+        );
+    }
+
+    @Test
+    void onlineAndNotBusyShouldLeadToIdleRunner() {
+        var ghRunner = new GHSelfHostedRunner(LINUX, ONLINE, false);
+        assertEquals(
+                SelfHostedRunnerStatus.IDLE,
+                ghRunner.getRunner().getSelfHostedRunnerStatus()
+        );
+    }
+
+    @Test
+    void offlineShouldAlwaysLeadToOfflineState() {
+        var ghRunner1 = new GHSelfHostedRunner(LINUX, OFFLINE, false);
+        var ghRunner2 = new GHSelfHostedRunner(LINUX, OFFLINE, true);
+        assertEquals(
+                SelfHostedRunnerStatus.OFFLINE,
+                ghRunner1.getRunner().getSelfHostedRunnerStatus()
+        );
+        assertEquals(
+                SelfHostedRunnerStatus.OFFLINE,
+                ghRunner2.getRunner().getSelfHostedRunnerStatus()
+        );
+    }
+
+    @Test
+    void unknownOperatingSystemNameShouldThrowException() {
+        var ghRunner1 = new GHSelfHostedRunner(
+                "unkown operating system", OFFLINE, false
+        );
+        assertThrows(
+                IllegalStateException.class,
+                ghRunner1::getRunner
+        );
+    }
+
+    @Test
+    void unknownStatusShouldThrowException() {
+        var ghRunner1 = new GHSelfHostedRunner(
+                LINUX, "unknown status", false
+        );
+        assertThrows(
+                IllegalStateException.class,
+                ghRunner1::getRunner
+        );
+    }
+}

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/SchedulingProperties.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/SchedulingProperties.java
@@ -7,6 +7,7 @@ public record SchedulingProperties(
         String workflowRunsInterval,
         String workflowRunBuildTimesInterval,
         String jobsInterval,
-        String pullRequestsInterval
+        String pullRequestsInterval,
+        String selfHostedRunnersInterval
 ) {
 }

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/selfhostedrunner/SelfHostedRunnerCountsExporter.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/selfhostedrunner/SelfHostedRunnerCountsExporter.java
@@ -1,0 +1,93 @@
+package be.xplore.githubmetrics.prometheusexporter.selfhostedrunner;
+
+import be.xplore.githubmetrics.domain.selfhostedrunner.GetAllSelfHostedRunnersUseCase;
+import be.xplore.githubmetrics.domain.selfhostedrunner.OperatingSystem;
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunner;
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunnerStatus;
+import be.xplore.githubmetrics.prometheusexporter.ScheduledExporter;
+import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class SelfHostedRunnerCountsExporter implements ScheduledExporter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SelfHostedRunnerCountsExporter.class);
+    private final GetAllSelfHostedRunnersUseCase getAllSelfHostedRunnersUseCase;
+    private final MeterRegistry registry;
+    private final String cronExpression;
+
+    public SelfHostedRunnerCountsExporter(
+            GetAllSelfHostedRunnersUseCase getAllSelfHostedRunnersUseCase,
+            SchedulingProperties schedulingProperties,
+            MeterRegistry registry
+
+    ) {
+        this.getAllSelfHostedRunnersUseCase = getAllSelfHostedRunnersUseCase;
+        this.registry = registry;
+        this.cronExpression = schedulingProperties.selfHostedRunnersInterval();
+    }
+
+    private void retrieveAndExportSelfHostedRunnerCounts() {
+        LOGGER.info("SelfHostedRunnerCounts scheduled task is running.");
+        List<SelfHostedRunner> selfHostedRunners = this.getAllSelfHostedRunnersUseCase.getAllSelfHostedRunners();
+        var runnerStates = this.countSelfHostedRunnerStates(selfHostedRunners);
+
+        for (Map.Entry<SelfHostedRunnerState, Integer> entry : runnerStates.entrySet()) {
+            Gauge.builder(
+                            "self_hosted_runners",
+                            entry,
+                            Map.Entry::getValue
+                    )
+                    .tag("os", entry.getKey().operatingSystem().toString())
+                    .tag("status", entry.getKey().status().toString())
+                    .strongReference(true)
+                    .register(this.registry);
+
+        }
+
+        LOGGER.debug("SelfHostedRunnerCounts scheduled task finished.");
+    }
+
+    private Map<SelfHostedRunnerState, Integer> countSelfHostedRunnerStates(
+            List<SelfHostedRunner> runners
+    ) {
+        var map = this.getStatesMap();
+        runners.forEach(runner -> {
+            var runnerState = new SelfHostedRunnerState(
+                    runner.getOperatingSystem(),
+                    runner.getSelfHostedRunnerStatus()
+            );
+            map.put(runnerState, map.getOrDefault(runnerState, 0) + 1);
+        });
+        return map;
+    }
+
+    private Map<SelfHostedRunnerState, Integer> getStatesMap() {
+        Map<SelfHostedRunnerState, Integer> map = new HashMap<>();
+        Arrays.stream(OperatingSystem.values()).forEach(os ->
+                Arrays.stream(SelfHostedRunnerStatus.values()).forEach(
+                        state -> map.put(new SelfHostedRunnerState(os, state), 0)
+                )
+        );
+        return map;
+    }
+
+    @Override
+    public void run() {
+        this.retrieveAndExportSelfHostedRunnerCounts();
+    }
+
+    @Override
+    public String cronExpression() {
+        return this.cronExpression;
+    }
+}

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/selfhostedrunner/SelfHostedRunnerState.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/selfhostedrunner/SelfHostedRunnerState.java
@@ -1,0 +1,10 @@
+package be.xplore.githubmetrics.prometheusexporter.selfhostedrunner;
+
+import be.xplore.githubmetrics.domain.selfhostedrunner.OperatingSystem;
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunnerStatus;
+
+public record SelfHostedRunnerState(
+        OperatingSystem operatingSystem,
+        SelfHostedRunnerStatus status
+) {
+}

--- a/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/selfhostedrunner/SelfHostedRunnerCountsExporterTest.java
+++ b/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/selfhostedrunner/SelfHostedRunnerCountsExporterTest.java
@@ -1,0 +1,81 @@
+package be.xplore.githubmetrics.prometheusexporter.selfhostedrunner;
+
+import be.xplore.githubmetrics.domain.selfhostedrunner.GetAllSelfHostedRunnersUseCase;
+import be.xplore.githubmetrics.domain.selfhostedrunner.OperatingSystem;
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunner;
+import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunnerStatus;
+import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SelfHostedRunnerCountsExporterTest {
+    private final GetAllSelfHostedRunnersUseCase getAllSelfHostedRunnersUseCase = mock(GetAllSelfHostedRunnersUseCase.class);
+    private final SchedulingProperties schedulingProperties = mock(SchedulingProperties.class);
+    private MeterRegistry registry;
+    private SelfHostedRunnerCountsExporter selfHostedRunnerCountsExporter;
+
+    @BeforeAll
+    static void beforeAll() {
+
+    }
+
+    private List<SelfHostedRunner> getSelfHostedRunners() {
+        return List.of(
+                new SelfHostedRunner(OperatingSystem.MAC_OS, SelfHostedRunnerStatus.BUSY),
+                new SelfHostedRunner(OperatingSystem.LINUX, SelfHostedRunnerStatus.BUSY),
+                new SelfHostedRunner(OperatingSystem.WINDOWS, SelfHostedRunnerStatus.BUSY),
+                new SelfHostedRunner(OperatingSystem.MAC_OS, SelfHostedRunnerStatus.IDLE),
+                new SelfHostedRunner(OperatingSystem.LINUX, SelfHostedRunnerStatus.IDLE),
+                new SelfHostedRunner(OperatingSystem.WINDOWS, SelfHostedRunnerStatus.IDLE),
+                new SelfHostedRunner(OperatingSystem.MAC_OS, SelfHostedRunnerStatus.OFFLINE),
+                new SelfHostedRunner(OperatingSystem.LINUX, SelfHostedRunnerStatus.OFFLINE),
+                new SelfHostedRunner(OperatingSystem.WINDOWS, SelfHostedRunnerStatus.OFFLINE),
+                new SelfHostedRunner(OperatingSystem.MAC_OS, SelfHostedRunnerStatus.BUSY),
+                new SelfHostedRunner(OperatingSystem.WINDOWS, SelfHostedRunnerStatus.IDLE)
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        when(this.getAllSelfHostedRunnersUseCase.getAllSelfHostedRunners()).thenReturn(
+                this.getSelfHostedRunners()
+        );
+
+        this.registry = new SimpleMeterRegistry();
+        this.selfHostedRunnerCountsExporter = new SelfHostedRunnerCountsExporter(
+                this.getAllSelfHostedRunnersUseCase,
+                schedulingProperties,
+                this.registry
+        );
+    }
+
+    @Test
+    void listOfSelfHostedRunnersShouldBeCountedInTheCorrectWay() {
+        selfHostedRunnerCountsExporter.run();
+        Arrays.stream(OperatingSystem.values()).forEach(os ->
+                Arrays.stream(SelfHostedRunnerStatus.values()).forEach(
+                        status ->
+                                assertEquals(
+                                        getSelfHostedRunners().stream().filter(runner ->
+                                                runner.getOperatingSystem().equals(os) &&
+                                                        runner.getSelfHostedRunnerStatus().equals(status)
+                                        ).count(),
+                                        this.registry.find("self_hosted_runners")
+                                                .tags("os", os.toString(), "status", status.toString())
+                                                .gauge().value()
+                                )
+                )
+        );
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ app:
         jobs_interval: ${APP_SCHEDULING_JOBS_INTERVAL:0 */5 * * * ?}
         workflow_run_build_times_interval: ${APP_SCHEDULING_WORKFLOW_RUN_BUILD_TIMES_INTERVAL:10 */5 * * * ?}
         pull_requests_interval: ${APP_SCHEDULING_PULL_REQUESTS_INTERVAL:0 */5 * * * ?}
+        self_hosted_runners_interval: ${SELF_HOSTED_RUNNERS_INTERVAL:20 */5 * * * ?}
     github:
         url: https://api.github.com
         org: "github-insights"

--- a/src/test/resources/__files/SelfHostedRunnersMacData.json
+++ b/src/test/resources/__files/SelfHostedRunnersMacData.json
@@ -1,0 +1,29 @@
+{
+    "total_count": 1,
+    "runners": [
+        {
+            "id": 20,
+            "name": "Thomass-MacBook-Pro",
+            "os": "macOS",
+            "status": "online",
+            "busy": false,
+            "labels": [
+                {
+                    "id": 1,
+                    "name": "self-hosted",
+                    "type": "read-only"
+                },
+                {
+                    "id": 2,
+                    "name": "macOS",
+                    "type": "read-only"
+                },
+                {
+                    "id": 3,
+                    "name": "ARM64",
+                    "type": "read-only"
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/__files/SelfHostedRunnersOtherData.json
+++ b/src/test/resources/__files/SelfHostedRunnersOtherData.json
@@ -1,0 +1,53 @@
+{
+    "total_count": 2,
+    "runners": [
+        {
+            "id": 21,
+            "name": "Thomass-MacBook-Pro",
+            "os": "linux",
+            "status": "online",
+            "busy": true,
+            "labels": [
+                {
+                    "id": 1,
+                    "name": "self-hosted",
+                    "type": "read-only"
+                },
+                {
+                    "id": 2,
+                    "name": "macOS",
+                    "type": "read-only"
+                },
+                {
+                    "id": 3,
+                    "name": "ARM64",
+                    "type": "read-only"
+                }
+            ]
+        },
+        {
+            "id": 23,
+            "name": "Thomass-MacBook-Pro",
+            "os": "windows",
+            "status": "offline",
+            "busy": false,
+            "labels": [
+                {
+                    "id": 1,
+                    "name": "self-hosted",
+                    "type": "read-only"
+                },
+                {
+                    "id": 2,
+                    "name": "macOS",
+                    "type": "read-only"
+                },
+                {
+                    "id": 3,
+                    "name": "ARM64",
+                    "type": "read-only"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
#40 Added feature that exposes the number of self hosted runners for a organization. Since runners can also be configured only on a specific repository, separate queries are made to both the org as well as every repository to get all the runners their status and os.

The status is a combination of the busy and status fields since not every combination of those is actually possible.

Reason for the flattening of the repository/org runners is becuase more then the state and number of runners is not interesting to us.