### PR TITLE
#120 Add some exports on startup

### DIFF
--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/StartupExporter.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/StartupExporter.java
@@ -1,0 +1,5 @@
+package be.xplore.githubmetrics.prometheusexporter;
+
+public interface StartupExporter {
+    void run();
+}

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/pullrequest/PullRequestExporter.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/pullrequest/PullRequestExporter.java
@@ -4,6 +4,7 @@ import be.xplore.githubmetrics.domain.pullrequest.GetAllPullRequestsUseCase;
 import be.xplore.githubmetrics.domain.pullrequest.PullRequest;
 import be.xplore.githubmetrics.domain.pullrequest.PullRequestState;
 import be.xplore.githubmetrics.prometheusexporter.ScheduledExporter;
+import be.xplore.githubmetrics.prometheusexporter.StartupExporter;
 import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -22,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 @Service
-public class PullRequestExporter implements ScheduledExporter {
+public class PullRequestExporter implements ScheduledExporter, StartupExporter {
     private static final Logger LOGGER = LoggerFactory.getLogger(PullRequestExporter.class);
     private static final List<Integer> STATE_COUNT_PERIODS = List.of(1, 2, 7, 28, 365);
     private static final List<Integer> THROUGHPUT_PERIODS = List.of(7, 14, 28, 365);

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/repository/RepositoryCountExporter.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/repository/RepositoryCountExporter.java
@@ -2,6 +2,7 @@ package be.xplore.githubmetrics.prometheusexporter.repository;
 
 import be.xplore.githubmetrics.domain.repository.GetAllRepositoriesUseCase;
 import be.xplore.githubmetrics.prometheusexporter.ScheduledExporter;
+import be.xplore.githubmetrics.prometheusexporter.StartupExporter;
 import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
-public class RepositoryCountExporter implements ScheduledExporter {
+public class RepositoryCountExporter implements ScheduledExporter, StartupExporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryCountExporter.class);
     private final GetAllRepositoriesUseCase getAllRepositoriesUseCase;

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunBuildTimesOfLastDayExporter.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/workflowrun/WorkflowRunBuildTimesOfLastDayExporter.java
@@ -4,6 +4,7 @@ import be.xplore.githubmetrics.domain.workflowrun.GetAllWorkflowRunBuildTimesOfL
 import be.xplore.githubmetrics.domain.workflowrun.WorkflowRun;
 import be.xplore.githubmetrics.domain.workflowrun.WorkflowRunStatus;
 import be.xplore.githubmetrics.prometheusexporter.ScheduledExporter;
+import be.xplore.githubmetrics.prometheusexporter.StartupExporter;
 import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -24,7 +25,7 @@ import java.util.stream.Stream;
 import static java.lang.Math.round;
 
 @Service
-public class WorkflowRunBuildTimesOfLastDayExporter implements ScheduledExporter {
+public class WorkflowRunBuildTimesOfLastDayExporter implements ScheduledExporter, StartupExporter {
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowRunBuildTimesOfLastDayExporter.class);
     private static final String TOTAL_GAUGE_NAME = "workflow_runs_total_build_times";
     private static final String AVERAGE_GAUGE_NAME = "workflow_runs_average_build_times";

--- a/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/MetricSchedulerTest.java
+++ b/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/MetricSchedulerTest.java
@@ -6,6 +6,7 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 
@@ -29,7 +30,7 @@ class MetricSchedulerTest {
                 .thenReturn(this.mockFuture);
         when(this.mockExporter.cronExpression()).thenReturn(CRON_EXP);
 
-        this.metricScheduler = new MetricScheduler(this.mockScheduler, List.of(this.mockExporter));
+        this.metricScheduler = new MetricScheduler(this.mockScheduler, List.of(this.mockExporter), new ArrayList<>());
         this.metricScheduler.configureTasks(mock(ScheduledTaskRegistrar.class));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,10 +21,10 @@ app:
         enable: true
         workflow_runs_interval: ${APP_SCHEDULING_WORKFLOW_RUNS_INTERVAL:30 */5 * * * ?}
         jobs_interval: ${APP_SCHEDULING_JOBS_INTERVAL:0 */5 * * * ?}
-        workflow_run_build_times_interval: ${APP_SCHEDULING_WORKFLOW_RUN_BUILD_TIMES_INTERVAL:10 */5 * * * ?}
-        pull_requests_interval: ${APP_SCHEDULING_PULL_REQUESTS_INTERVAL:0 */5 * * * ?}
+        workflow_run_build_times_interval: ${APP_SCHEDULING_WORKFLOW_RUN_BUILD_TIMES_INTERVAL:10 0 * * * ?}
+        pull_requests_interval: ${APP_SCHEDULING_PULL_REQUESTS_INTERVAL:15 0 * * * ?}
         self_hosted_runners_interval: ${SELF_HOSTED_RUNNERS_INTERVAL:20 */5 * * * ?}
-        repository_count_interval: ${REPOSITORY_COUNT_INTERVAL:0 */5 * * * ?}
+        repository_count_interval: ${REPOSITORY_COUNT_INTERVAL:0 0 * * * ?}
     github:
         url: https://api.github.com
         org: "github-insights"


### PR DESCRIPTION
Repositories, pull requests, and workflow build minutes metrics are not often required so are not scheduled often but should run once on startup.