### PR TITLE
exprting api state

### DIFF
--- a/domain/src/main/java/be/xplore/githubmetrics/domain/apistate/ApiRateLimitState.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/apistate/ApiRateLimitState.java
@@ -17,8 +17,8 @@ public class ApiRateLimitState {
     private long reset;
     private long used;
     private Optional<ApiRateLimitStatus> status = Optional.of(ApiRateLimitStatus.OK);
-    private double actualRequestsPerMilli;
-    private double idealRequestsPerMilli;
+    private double actualRequestsPerSecond;
+    private double idealRequestsPerSecond;
 
     public ApiRateLimitState(
             double rateLimitBuffer,
@@ -39,8 +39,8 @@ public class ApiRateLimitState {
             double idealRequestsPerSecond
     ) {
         this.status.ifPresent(currentStatus -> {
-            this.actualRequestsPerMilli = actualRequestsPerSecond;
-            this.idealRequestsPerMilli = idealRequestsPerSecond;
+            this.actualRequestsPerSecond = actualRequestsPerSecond;
+            this.idealRequestsPerSecond = idealRequestsPerSecond;
 
             var newStatus = this.getNewAbsoluteStatus();
 
@@ -54,13 +54,13 @@ public class ApiRateLimitState {
 
     public ApiRateLimitStatus getNewAbsoluteStatus() {
         ApiRateLimitStatus newStatus;
-        if (this.idealRequestsPerMilli * this.goodLimit >= this.actualRequestsPerMilli) {
+        if (this.idealRequestsPerSecond * this.goodLimit >= this.actualRequestsPerSecond) {
             newStatus = ApiRateLimitStatus.OK;
-        } else if (this.idealRequestsPerMilli * this.concerningLimit >= this.actualRequestsPerMilli) {
+        } else if (this.idealRequestsPerSecond * this.concerningLimit >= this.actualRequestsPerSecond) {
             newStatus = ApiRateLimitStatus.GOOD;
-        } else if (this.idealRequestsPerMilli * this.warningLimit >= this.actualRequestsPerMilli) {
+        } else if (this.idealRequestsPerSecond * this.warningLimit >= this.actualRequestsPerSecond) {
             newStatus = ApiRateLimitStatus.CONCERNING;
-        } else if (this.idealRequestsPerMilli * this.criticalLimit >= this.actualRequestsPerMilli) {
+        } else if (this.idealRequestsPerSecond * this.criticalLimit >= this.actualRequestsPerSecond) {
             newStatus = ApiRateLimitStatus.WARNING;
         } else {
             newStatus = ApiRateLimitStatus.CRITICAL;
@@ -139,12 +139,12 @@ public class ApiRateLimitState {
         this.used = used;
     }
 
-    public double getActualRequestsPerMilli() {
-        return actualRequestsPerMilli;
+    public double getActualRequestsPerSecond() {
+        return actualRequestsPerSecond;
     }
 
-    public double getIdealRequestsPerMilli() {
-        return idealRequestsPerMilli;
+    public double getIdealRequestsPerSecond() {
+        return idealRequestsPerSecond;
     }
 
     public Optional<ApiRateLimitStatus> getStatus() {

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/apistate/ApiRateLimitStateQueryPort.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/apistate/ApiRateLimitStateQueryPort.java
@@ -1,0 +1,5 @@
+package be.xplore.githubmetrics.domain.apistate;
+
+public interface ApiRateLimitStateQueryPort {
+    ApiRateLimitState getCurrentApiRateLimitState();
+}

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/apistate/GetCurrentApiRateLimitStateUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/apistate/GetCurrentApiRateLimitStateUseCase.java
@@ -1,0 +1,19 @@
+package be.xplore.githubmetrics.domain.apistate;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class GetCurrentApiRateLimitStateUseCase {
+
+    private final ApiRateLimitStateQueryPort apiRateLimitStateQueryPort;
+
+    public GetCurrentApiRateLimitStateUseCase(
+            ApiRateLimitStateQueryPort apiRateLimitStateQueryPort
+    ) {
+        this.apiRateLimitStateQueryPort = apiRateLimitStateQueryPort;
+    }
+
+    public ApiRateLimitState getCurrentApiRateLimitState() {
+        return this.apiRateLimitStateQueryPort.getCurrentApiRateLimitState();
+    }
+}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/ApiRateLimitStateAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/ApiRateLimitStateAdapter.java
@@ -1,0 +1,19 @@
+package be.xplore.githubmetrics.githubadapter.config.ratelimiting;
+
+import be.xplore.githubmetrics.domain.apistate.ApiRateLimitState;
+import be.xplore.githubmetrics.domain.apistate.ApiRateLimitStateQueryPort;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ApiRateLimitStateAdapter implements ApiRateLimitStateQueryPort {
+    private final ApiRateLimitState rateLimitState;
+
+    public ApiRateLimitStateAdapter(ApiRateLimitState rateLimitState) {
+        this.rateLimitState = rateLimitState;
+    }
+
+    @Override
+    public ApiRateLimitState getCurrentApiRateLimitState() {
+        return this.rateLimitState;
+    }
+}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitingInterceptor.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitingInterceptor.java
@@ -207,7 +207,7 @@ public class RateLimitingInterceptor implements ClientHttpRequestInterceptor {
         LOGGER.debug("{} Requests in period {}", numRequestsInDuration, this.getCountingDuration());
         LOGGER.debug(
                 "Actual {} req/s / Ideal {} req/s",
-                this.rateLimitState.getActualRequestsPerMilli(), this.rateLimitState.getIdealRequestsPerMilli()
+                this.rateLimitState.getActualRequestsPerSecond(), this.rateLimitState.getIdealRequestsPerSecond()
         );
         LOGGER.trace(
                 "Limit {} Remaining {} Used {}",

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/apistate/ApiRateLimitStateExporter.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/apistate/ApiRateLimitStateExporter.java
@@ -1,0 +1,103 @@
+package be.xplore.githubmetrics.prometheusexporter.apistate;
+
+import be.xplore.githubmetrics.domain.apistate.ApiRateLimitState;
+import be.xplore.githubmetrics.domain.apistate.ApiRateLimitStatus;
+import be.xplore.githubmetrics.domain.apistate.GetCurrentApiRateLimitStateUseCase;
+import be.xplore.githubmetrics.prometheusexporter.ScheduledExporter;
+import be.xplore.githubmetrics.prometheusexporter.config.SchedulingProperties;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Service
+public class ApiRateLimitStateExporter implements ScheduledExporter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiRateLimitStateExporter.class);
+
+    private static final String LIMIT = "api_ratelimit_state_limit";
+    private static final String REMAINING = "api_ratelimit_state_remaining";
+    private static final String RESET = "api_ratelimit_state_reset";
+    private static final String USED = "api_ratelimit_state_used";
+    private static final String STATUS = "api_ratelimit_state_status";
+    private static final String PAUSED = "api_ratelimit_state_paused";
+    private static final String ACTUAL = "api_ratelimit_state_actual_req";
+    private static final String IDEAL = "api_ratelimit_state_ideal_req";
+
+    private final String cronExpression;
+    private final GetCurrentApiRateLimitStateUseCase getCurrentApiRateLimitStateUseCase;
+    private final Map<String, AtomicLong> rateLimitStateGauges = new HashMap<>();
+
+    public ApiRateLimitStateExporter(
+            GetCurrentApiRateLimitStateUseCase getCurrentApiRateLimitStateUseCase,
+            SchedulingProperties schedulingProperties,
+            MeterRegistry registry
+    ) {
+        this.getCurrentApiRateLimitStateUseCase = getCurrentApiRateLimitStateUseCase;
+        this.cronExpression = schedulingProperties.apiRateLimitState();
+
+        this.initRateLimitGauges(registry);
+    }
+
+    private void retrieveAndExportApiRateLimitState() {
+        LOGGER.trace("ApiRateLimitState scheduled task is running.");
+        var currentState = this.getCurrentApiRateLimitStateUseCase.getCurrentApiRateLimitState();
+        this.updateHeaderData(currentState);
+        this.updateStatusData(currentState);
+        this.updateRequestsPerSecData(currentState);
+        LOGGER.trace("ApiRateLimitState scheduled task is finished.");
+    }
+
+    private void updateHeaderData(ApiRateLimitState state) {
+        put(LIMIT, state.getLimit());
+        put(REMAINING, state.getRemaining());
+        put(RESET, state.getReset());
+        put(USED, state.getUsed());
+    }
+
+    private void updateStatusData(ApiRateLimitState state) {
+        var statusVal = state.getStatus().orElse(ApiRateLimitStatus.CRITICAL).ordinal();
+        var paused = state.getStatus().map(status -> 0.0).orElse(1.0);
+        put(STATUS, statusVal);
+        put(PAUSED, paused);
+    }
+
+    private void updateRequestsPerSecData(ApiRateLimitState state) {
+        put(ACTUAL, state.getActualRequestsPerSecond());
+        put(IDEAL, state.getIdealRequestsPerSecond());
+    }
+
+    private void put(String name, double newVal) {
+        this.rateLimitStateGauges.get(name)
+                .set(Double.doubleToLongBits(newVal));
+    }
+
+    private void initRateLimitGauges(MeterRegistry registry) {
+        var metrics = List.of(
+                LIMIT, REMAINING, RESET, USED, STATUS, PAUSED, ACTUAL, IDEAL
+        );
+        metrics.forEach(metricName -> {
+            var atomicLong = new AtomicLong();
+            Gauge.builder(
+                            metricName, () -> Double.longBitsToDouble(atomicLong.get())
+                    ).strongReference(true)
+                    .register(registry);
+            this.rateLimitStateGauges.put(metricName, atomicLong);
+        });
+    }
+
+    @Override
+    public void run() {
+        this.retrieveAndExportApiRateLimitState();
+    }
+
+    @Override
+    public String cronExpression() {
+        return this.cronExpression;
+    }
+}

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/SchedulingProperties.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/config/SchedulingProperties.java
@@ -10,6 +10,7 @@ public record SchedulingProperties(
         String jobs,
         String pullRequests,
         String selfHostedRunners,
-        String repositoryCount
+        String repositoryCount,
+        String apiRateLimitState
 ) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ app:
             pull_requests: ${EXPORTERS_SCHEDULING_PULL_REQUESTS:*/30 * * * * ?}
             self_hosted_runners: ${EXPORTERS_SCHEDULING_SELF_HOSTED_RUNNERS:*/30 * * * * ?}
             repository_count: ${EXPORTERS_SCHEDULING_REPOSITORY_COUNT:*/30 * * * * ?}
+            api_ratelimit_state: ${EXPORTERS_SCHEDULING_API_RATELIMIT_STATE:*/15 * * * * ?}
         cacheeviction:
             enable: true
             workflow_runs:


### PR DESCRIPTION
#156 Through a new exporter the ApiRateLimitState is now exposed on the actuator endpoint. With this the rate-limit state can now be monitored on the Grafana side.

Two things to note here are:
- The status Enum is converted to ordinal and set to CRITICAL in the case that the Optional is empty
- When the optional is empty the api_ratelimit_state_paused metric is set to 1 indicating that the requesting has being paused.