### PR TITLE
restclient observability

### DIFF
--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/GithubApiUtilities.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/GithubApiUtilities.java
@@ -23,8 +23,31 @@ public class GithubApiUtilities {
     private static final Logger LOGGER = LoggerFactory.getLogger(GithubApiUtilities.class);
     private final RestClient restClient;
 
-    public GithubApiUtilities(@Qualifier("defaultRestClient") RestClient restClient) {
+    public GithubApiUtilities(
+            @Qualifier("defaultRestClient") RestClient restClient
+    ) {
         this.restClient = restClient;
+    }
+
+    public Function<UriBuilder, URI> setPathAndParameters(
+            String path,
+            List<Object> uriVariables
+    ) {
+        return uriBuilder ->
+                uriBuilder.path(path)
+                        .build(uriVariables.toArray(new Object[0]));
+    }
+
+    public Function<UriBuilder, URI> setPathAndParameters(
+            String path,
+            List<Object> uriVariables,
+            Map<String, String> parameters
+    ) {
+        return uriBuilder -> {
+            uriBuilder.path(path);
+            parameters.forEach(uriBuilder::queryParam);
+            return uriBuilder.build(uriVariables.toArray(new Object[0]));
+        };
     }
 
     public Function<UriBuilder, URI> setPathAndParameters(

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/RepositoriesAdapter.java
@@ -21,6 +21,7 @@ import java.util.List;
 @Service
 public class RepositoriesAdapter implements RepositoriesQueryPort, ScheduledCacheEvictionPort {
     private static final String REPOSITORIES_CACHE_NAME = "Repositories";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(RepositoriesAdapter.class);
 
     private final RestClient restClient;
@@ -52,9 +53,10 @@ public class RepositoriesAdapter implements RepositoriesQueryPort, ScheduledCach
 
         ResponseEntity<GHRepositories> responseEntity = this.restClient.get()
                 .uri(utilities.setPathAndParameters(
-                        "/installation/repositories",
+                        GHRepositories.PATH,
                         parameters
                 ))
+                .header("path", GHRepositories.PATH)
                 .retrieve()
                 .toEntity(GHRepositories.class);
 

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientConfig.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientConfig.java
@@ -4,6 +4,7 @@ import be.xplore.githubmetrics.githubadapter.config.auth.GithubAuthTokenIntercep
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubJwtTokenInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubUnauthorizedInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.ratelimiting.RateLimitingInterceptor;
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatusCode;
@@ -16,17 +17,23 @@ public class GithubRestClientConfig {
     private final DebugInterceptor debugInterceptor;
     private final GithubProperties githubProperties;
     private final RateLimitingInterceptor rateLimitingInterceptor;
+    private final ObservationRegistry observationRegistry;
+    private final GithubRestClientRequestObservationConvention githubRestClientRequestObservationConvention;
 
     public GithubRestClientConfig(
             GithubUnauthorizedInterceptor unauthorizedInterceptor,
             DebugInterceptor debugInterceptor,
             GithubProperties githubProperties,
-            RateLimitingInterceptor rateLimitingInterceptor
+            RateLimitingInterceptor rateLimitingInterceptor,
+            ObservationRegistry observationRegistry,
+            GithubRestClientRequestObservationConvention githubRestClientRequestObservationConvention
     ) {
         this.unauthorizedInterceptor = unauthorizedInterceptor;
         this.debugInterceptor = debugInterceptor;
         this.githubProperties = githubProperties;
         this.rateLimitingInterceptor = rateLimitingInterceptor;
+        this.observationRegistry = observationRegistry;
+        this.githubRestClientRequestObservationConvention = githubRestClientRequestObservationConvention;
     }
 
     @Bean
@@ -55,6 +62,8 @@ public class GithubRestClientConfig {
     private RestClient.Builder getBasicRestClient() {
         return RestClient.builder()
                 .baseUrl(githubProperties.url())
+                .observationRegistry(this.observationRegistry)
+                .observationConvention(this.githubRestClientRequestObservationConvention)
                 .defaultHeaders(
                         httpHeaders -> {
                             httpHeaders.set("X-Github-Api-Version", "2022-11-28");

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientRequestObservationConvention.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientRequestObservationConvention.java
@@ -1,0 +1,72 @@
+package be.xplore.githubmetrics.githubadapter.config;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.observation.ClientHttpObservationDocumentation;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
+import org.springframework.http.client.observation.ClientRequestObservationConvention;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Component
+public class GithubRestClientRequestObservationConvention implements ClientRequestObservationConvention {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GithubRestClientRequestObservationConvention.class);
+
+    @Override
+    public String getName() {
+        return "http.client.requests";
+    }
+
+    @Override
+    public KeyValues getLowCardinalityKeyValues(ClientRequestObservationContext context) {
+        return KeyValues.of(method(context), status(context), uri(context));
+    }
+
+    protected KeyValue uri(ClientRequestObservationContext context) {
+        String uri = Optional.ofNullable(context.getCarrier().getHeaders().get("path")).map(list -> {
+            if (!list.isEmpty()) {
+                return list.getFirst();
+            } else {
+                return "NO HEADER";
+            }
+        }).orElse("NO HEADER");
+        return KeyValue.of("uri", uri);
+    }
+
+    protected KeyValue method(ClientRequestObservationContext context) {
+        return KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.METHOD, context.getCarrier().getMethod().toString());
+    }
+
+    protected KeyValue status(ClientRequestObservationContext context) {
+        String statusCode = Optional.ofNullable(context.getResponse()).map(response -> {
+            String out = "";
+            try {
+                HttpStatusCode httpStatusCode = response.getStatusCode();
+                if (httpStatusCode.is1xxInformational()) {
+                    out = "1xx";
+                } else if (httpStatusCode.is2xxSuccessful()) {
+                    out = "2xx";
+                } else if (httpStatusCode.is3xxRedirection()) {
+                    out = "3xx";
+                } else if (httpStatusCode.is4xxClientError()) {
+                    out = "4xx";
+                } else if (httpStatusCode.is5xxServerError()) {
+                    out = "5xx";
+                }
+            } catch (IOException e) {
+                LOGGER.trace("ERROR: Status Code was not preset on the context response.");
+            }
+            return out;
+        }).orElse("");
+
+        var val = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.STATUS, statusCode);
+        LOGGER.error("{}", val);
+        return val;
+    }
+
+}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ObservabilityConfig.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ObservabilityConfig.java
@@ -1,0 +1,13 @@
+package be.xplore.githubmetrics.githubadapter.config;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObservabilityConfig {
+    @Bean
+    ObservationRegistry observationRegistry() {
+        return ObservationRegistry.create();
+    }
+}

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/auth/GithubAuthTokenInterceptor.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/auth/GithubAuthTokenInterceptor.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import java.io.IOException;
-import java.text.MessageFormat;
 import java.time.ZonedDateTime;
 
 @Component
@@ -47,20 +46,17 @@ public class GithubAuthTokenInterceptor implements ClientHttpRequestInterceptor 
 
         LOGGER.debug("Access token has expired getting a new one.");
         var accessToken = this.tokenFetcherRestClient.post()
-                .uri(this.getAccessTokenApiPath())
+                .uri(uriBuilder -> uriBuilder.path(GHAppInstallationAccessToken.PATH)
+                        .build(githubProperties.application().installId())
+                )
+                .header("path", GHAppInstallationAccessToken.PATH)
                 .retrieve()
                 .body(GHAppInstallationAccessToken.class);
         assert accessToken != null;
+
         this.currentAccessToken = accessToken.token();
         this.tokenExpirationDateTime = accessToken.getActualDate();
         return this.currentAccessToken;
-    }
-
-    private String getAccessTokenApiPath() {
-        return MessageFormat.format(
-                "/app/installations/{0}/access_tokens",
-                githubProperties.application().installId()
-        );
     }
 
     private ZonedDateTime now() {

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHActionRunTiming.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHActionRunTiming.java
@@ -3,4 +3,6 @@ package be.xplore.githubmetrics.githubadapter.mappingclasses;
 public record GHActionRunTiming(
         int run_duration_ms
 ) {
+
+    public static final String PATH = "repos/{org}/{repo}/actions/runs/{workflowRunId}/timing";
 }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHActionRuns.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHActionRuns.java
@@ -9,6 +9,8 @@ public record GHActionRuns(
         int total_count,
         List<GHActionRun> workflow_runs
 ) {
+    public static final String PATH = "repos/{org}/{repo}/actions/runs";
+
     public List<WorkflowRun> getWorkFlowRuns(Repository repository) {
         return this.workflow_runs.stream().map(workflowRun ->
                 workflowRun.getWorkFlowRun(repository)

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHAppInstallationAccessToken.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHAppInstallationAccessToken.java
@@ -7,6 +7,8 @@ public record GHAppInstallationAccessToken(
         String token,
         String expires_at
 ) {
+    public static final String PATH = "/app/installations/{appId}/access_tokens";
+
     public ZonedDateTime getActualDate() {
         return Instant
                 .parse(this.expires_at)

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHPullRequest.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHPullRequest.java
@@ -12,6 +12,7 @@ public record GHPullRequest(
         String closed_at,
         String merged_at
 ) {
+    public static final String PATH_ALL = "/repos/{org}/{repo}/pulls";
 
     private ZonedDateTime getZonedDateTime(String date) {
         return Instant.parse(date).atZone(ZoneId.of("Etc/UTC"));

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHRepositories.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHRepositories.java
@@ -8,6 +8,8 @@ import java.util.List;
 public record GHRepositories(
         List<GHRepository> repositories
 ) {
+    public static final String PATH = "/installation/repositories";
+
     public List<Repository> getRepositories() {
         List<Repository> repositoryList = new ArrayList<>();
         repositories.forEach(repository -> repositoryList.add(repository.getRepository()));

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunners.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunners.java
@@ -8,6 +8,10 @@ public record GHSelfHostedRunners(
         long total_count,
         List<GHSelfHostedRunner> runners
 ) {
+
+    public static final String PATH_ORG = "orgs/{org}/actions/runners";
+    public static final String PATH_REPO = "repos/{org}/{repo}/actions/runners";
+
     public List<SelfHostedRunner> getRunners() {
         return this.runners.stream().map(GHSelfHostedRunner::getRunner).toList();
     }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHWorkflowRunJobs.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHWorkflowRunJobs.java
@@ -8,6 +8,8 @@ public record GHWorkflowRunJobs(
         int total_count,
         List<GHJob> jobs
 ) {
+    public static final String PATH = "repos/{org}/{repo}/actions/runs/{workflowRunId}/jobs";
+
     public List<Job> getJobs() {
         return this.jobs.stream().map(
                 GHJob::getJob

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/TestUtility.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/TestUtility.java
@@ -6,12 +6,14 @@ import be.xplore.githubmetrics.githubadapter.cacheevicting.CacheEvictionProperti
 import be.xplore.githubmetrics.githubadapter.config.DebugInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
 import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfig;
+import be.xplore.githubmetrics.githubadapter.config.GithubRestClientRequestObservationConvention;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubAuthTokenInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubJwtTokenInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubUnauthorizedInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.ratelimiting.RateLimitResetAwaitScheduler;
 import be.xplore.githubmetrics.githubadapter.config.ratelimiting.RateLimitingInterceptor;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.client.RestClient;
@@ -48,7 +50,9 @@ public class TestUtility {
 
     public static GithubAuthTokenInterceptor getAuthTokenInterceptor(GithubProperties githubProperties) {
         var restClientConfig = new GithubRestClientConfig(
-                new GithubUnauthorizedInterceptor(), DEBUG_INTERCEPTOR, githubProperties, getRateLimitingInterceptor()
+                new GithubUnauthorizedInterceptor(), DEBUG_INTERCEPTOR,
+                githubProperties, getRateLimitingInterceptor(), mock(ObservationRegistry.NOOP),
+                mock(GithubRestClientRequestObservationConvention.class)
         );
         var jwtInterceptor = new GithubJwtTokenInterceptor(githubProperties);
         var jwtRestClient = restClientConfig.tokenFetcherRestClient(

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunBuildTimesAdapterTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/WorkflowRunBuildTimesAdapterTest.java
@@ -68,7 +68,8 @@ class WorkflowRunBuildTimesAdapterTest {
         buildTimesAdapter = new WorkflowRunBuildTimesAdapter(
                 githubProperties, tokenRestClient,
                 TestUtility.getCacheEvictionProperties(),
-                TestUtility.getApiRateLimitState()
+                TestUtility.getApiRateLimitState(),
+                new GithubApiUtilities(tokenRestClient)
         );
 
         this.workflowRun = new WorkflowRun(

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/auth/GithubAuthTokenInterceptorTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/auth/GithubAuthTokenInterceptorTest.java
@@ -4,11 +4,13 @@ import be.xplore.githubmetrics.githubadapter.TestUtility;
 import be.xplore.githubmetrics.githubadapter.config.DebugInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
 import be.xplore.githubmetrics.githubadapter.config.GithubRestClientConfig;
+import be.xplore.githubmetrics.githubadapter.config.GithubRestClientRequestObservationConvention;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubAuthTokenInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubJwtTokenInterceptor;
 import be.xplore.githubmetrics.githubadapter.config.auth.GithubUnauthorizedInterceptor;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -44,7 +46,9 @@ class GithubAuthTokenInterceptorTest {
             new GithubUnauthorizedInterceptor(),
             new DebugInterceptor(),
             githubProperties,
-            TestUtility.getRateLimitingInterceptor()
+            TestUtility.getRateLimitingInterceptor(),
+            ObservationRegistry.NOOP,
+            mock(GithubRestClientRequestObservationConvention.class)
     );
 
     private GithubAuthTokenInterceptor authTokenInterceptor;

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientRequestObservationConventionTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientRequestObservationConventionTest.java
@@ -1,0 +1,110 @@
+package be.xplore.githubmetrics.githubadapter.config;
+
+import io.micrometer.common.KeyValues;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GithubRestClientRequestObservationConventionTest {
+    private static final String PATH = "path";
+    private static final String URI = "uri";
+    private static final String STATUS = "status";
+
+    private GithubRestClientRequestObservationConvention observationConvention;
+    private ClientRequestObservationContext mockObservationContext;
+    private HttpHeaders mockHeaders;
+
+    @BeforeEach
+    void setUp() {
+        this.observationConvention = new GithubRestClientRequestObservationConvention();
+        this.mockObservationContext = mock(ClientRequestObservationContext.class);
+        ClientHttpRequest mockCarrier = mock(ClientHttpRequest.class);
+        this.mockHeaders = mock(HttpHeaders.class);
+        when(mockObservationContext.getCarrier()).thenReturn(mockCarrier);
+        when(mockCarrier.getHeaders()).thenReturn(mockHeaders);
+        when(mockCarrier.getMethod()).thenReturn(HttpMethod.GET);
+    }
+
+    @Test
+    void conventionShouldParsePathHeaderCorrectly() {
+        String path = "my/special/path";
+
+        when(mockHeaders.get(PATH)).thenReturn(List.of(path));
+        assertTrue(keyValPresent(URI, path));
+    }
+
+    @Test
+    void conventionShouldReturnNOHEADERifNoValue() {
+        when(mockHeaders.get(PATH)).thenReturn(List.of());
+        assertTrue(keyValPresent(URI, "NO HEADER"));
+    }
+
+    @Test
+    void conventionShouldReturnNOHEADERifNoHeader() {
+        assertTrue(keyValPresent(URI, "NO HEADER"));
+    }
+
+    @Test
+    void emptyContextResponseShouldTranslateToEmptyResponseCodeLabel() {
+        assertTrue(keyValPresent(STATUS, ""));
+    }
+
+    @Test
+    void conventionResponseCodesShouldTranslateToCorrectStrings() throws IOException {
+        try (ClientHttpResponse response = mock(ClientHttpResponse.class)) {
+            when(mockObservationContext.getResponse()).thenReturn(response);
+            setupResponse(response);
+            checkStatusCodes();
+        }
+    }
+
+    @Test
+    void responseCodeThrowingExceptionShouldStillReturnStatus() throws IOException {
+        try (ClientHttpResponse response = mock(ClientHttpResponse.class)) {
+            when(mockObservationContext.getResponse()).thenReturn(response);
+            when(response.getStatusCode()).thenThrow(IOException.class);
+
+            assertTrue(keyValPresent(STATUS, ""));
+        }
+    }
+
+    private void setupResponse(ClientHttpResponse response) throws IOException {
+        when(response.getStatusCode())
+                .thenReturn(HttpStatusCode.valueOf(101))
+                .thenReturn(HttpStatusCode.valueOf(201))
+                .thenReturn(HttpStatusCode.valueOf(301))
+                .thenReturn(HttpStatusCode.valueOf(401))
+                .thenReturn(HttpStatusCode.valueOf(501));
+    }
+
+    private void checkStatusCodes() {
+        assertTrue(keyValPresent(STATUS, "1xx"));
+        assertTrue(keyValPresent(STATUS, "2xx"));
+        assertTrue(keyValPresent(STATUS, "3xx"));
+        assertTrue(keyValPresent(STATUS, "4xx"));
+        assertTrue(keyValPresent(STATUS, "5xx"));
+    }
+
+    private boolean keyValPresent(String key, String val) {
+        return get().stream().anyMatch(keyValue ->
+                keyValue.getKey().equals(key) && keyValue.getValue().equals(val)
+        );
+    }
+
+    private KeyValues get() {
+        return this.observationConvention.getLowCardinalityKeyValues(this.mockObservationContext);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,7 @@ logging:
     level:
         be.xplore.githubmetrics:
             ROOT: ${LOGGING_LEVEL:INFO}
+            githubadapter.config: TRACE
 
 management:
     endpoints:


### PR DESCRIPTION
#155 All RestClients now expose some metrics on the actuator endpoint. The exposed metrics values have not been modified in any way from the default. The only thing that changed is that the uri path tag has been modified, removing the path variables to decrease the cardinality of the metrics.