### PR TITLE
fixed selfhosted runner os parsing error

### DIFF
--- a/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/OperatingSystem.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/OperatingSystem.java
@@ -1,5 +1,5 @@
 package be.xplore.githubmetrics.domain.selfhostedrunner;
 
 public enum OperatingSystem {
-    MAC_OS, LINUX, WINDOWS
+    MAC_OS, LINUX, WINDOWS, UNKNOWN
 }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/SelfHostedRunnerAdapter.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/SelfHostedRunnerAdapter.java
@@ -102,7 +102,7 @@ public class SelfHostedRunnerAdapter implements SelfHostedRunnersQueryPort, Sche
 
         return this.utilities.followPaginationLink(
                 responseEntity,
-                GHSelfHostedRunners::getRunners,
+                ghSelfHostedRunners -> ghSelfHostedRunners.getRunners(this.githubProperties.parsing().selfHostedRunnerOsKeywords()),
                 GHSelfHostedRunners.class
         );
     }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubProperties.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubProperties.java
@@ -2,12 +2,19 @@ package be.xplore.githubmetrics.githubadapter.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
 @ConfigurationProperties(prefix = "app.github")
 public record GithubProperties(
         String url,
         String org,
         Application application,
-        RateLimiting ratelimiting
+        RateLimiting ratelimiting,
+        Parsing parsing
 ) {
     public record Application(
             String id,
@@ -24,5 +31,40 @@ public record GithubProperties(
             double concerningLimit,
             double goodLimit
     ) {
+    }
+
+    public record Parsing(
+            SelfHostedRunnerOsKeywords selfHostedRunnerOsKeywords
+    ) {
+        public record SelfHostedRunnerOsKeywords(
+                String linux,
+                String windows,
+                String macos
+        ) {
+
+            public List<String> linuxKeywords() {
+                return splitCleanAndAdd(this.linux, "linux");
+            }
+
+            public List<String> windowsKeywords() {
+                return splitCleanAndAdd(this.windows, "windows");
+            }
+
+            public List<String> macosKeywords() {
+                return splitCleanAndAdd(this.macos, "macos");
+            }
+
+            private List<String> splitCleanAndAdd(String keywords, String... defaultKeywords) {
+                List<String> cleanedKeywords = Stream.concat(
+                                Arrays.stream(keywords.split(",")),
+                                Arrays.stream(defaultKeywords)
+                        )
+                        .map(keyword -> keyword.toLowerCase(Locale.ROOT))
+                        .filter(word -> !word.isBlank()).toList();
+                return new ArrayList<>(cleanedKeywords);
+            }
+
+        }
+
     }
 }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientRequestObservationConvention.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubRestClientRequestObservationConvention.java
@@ -64,9 +64,7 @@ public class GithubRestClientRequestObservationConvention implements ClientReque
             return out;
         }).orElse("");
 
-        var val = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.STATUS, statusCode);
-        LOGGER.error("{}", val);
-        return val;
+        return KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.STATUS, statusCode);
     }
 
 }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunner.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunner.java
@@ -3,28 +3,42 @@ package be.xplore.githubmetrics.githubadapter.mappingclasses;
 import be.xplore.githubmetrics.domain.selfhostedrunner.OperatingSystem;
 import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunner;
 import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunnerStatus;
+import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.text.MessageFormat;
+import java.util.List;
+import java.util.Locale;
 
 public record GHSelfHostedRunner(
         String os,
         String status,
         boolean busy
 ) {
-    public SelfHostedRunner getRunner() {
-        return new SelfHostedRunner(this.getOs(), this.getStatus());
+    private static final Logger LOGGER = LoggerFactory.getLogger(GHSelfHostedRunner.class);
+
+    public SelfHostedRunner getRunner(GithubProperties.Parsing.SelfHostedRunnerOsKeywords keywords) {
+        return new SelfHostedRunner(this.getOs(keywords), this.getStatus());
     }
 
-    private OperatingSystem getOs() {
-        return switch (this.os) {
-            case "linux" -> OperatingSystem.LINUX;
-            case "windows" -> OperatingSystem.WINDOWS;
-            case "macOS" -> OperatingSystem.MAC_OS;
-            default -> throw new IllegalStateException(MessageFormat.format(
-                    "The string {0} could not be parsed to the OperatingSystem enum.",
-                    this.os
-            ));
-        };
+    @SuppressWarnings("checkstyle:ReturnCount")
+    private OperatingSystem getOs(GithubProperties.Parsing.SelfHostedRunnerOsKeywords keywords) {
+        if (osContainsAny(keywords.linuxKeywords())) {
+            return OperatingSystem.LINUX;
+        } else if (osContainsAny(keywords.windowsKeywords())) {
+            return OperatingSystem.WINDOWS;
+        } else if (osContainsAny(keywords.macosKeywords())) {
+            return OperatingSystem.MAC_OS;
+        } else {
+            LOGGER.warn("Unknown operating system encountered. Please update the keywords so that we are able to match the os to one of the options.");
+            LOGGER.warn("Consider that all keywords and os's are treated as lowercase. Os was {}", this.os);
+            return OperatingSystem.UNKNOWN;
+        }
+    }
+
+    private boolean osContainsAny(List<String> list) {
+        return list.stream().anyMatch(this.os.toLowerCase(Locale.ROOT)::contains);
     }
 
     private SelfHostedRunnerStatus getStatus() {

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunners.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunners.java
@@ -1,6 +1,7 @@
 package be.xplore.githubmetrics.githubadapter.mappingclasses;
 
 import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunner;
+import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
 
 import java.util.List;
 
@@ -12,7 +13,7 @@ public record GHSelfHostedRunners(
     public static final String PATH_ORG = "orgs/{org}/actions/runners";
     public static final String PATH_REPO = "repos/{org}/{repo}/actions/runners";
 
-    public List<SelfHostedRunner> getRunners() {
-        return this.runners.stream().map(GHSelfHostedRunner::getRunner).toList();
+    public List<SelfHostedRunner> getRunners(GithubProperties.Parsing.SelfHostedRunnerOsKeywords keywords) {
+        return this.runners.stream().map(ghSelfHostedRunner -> ghSelfHostedRunner.getRunner(keywords)).toList();
     }
 }

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/TestUtility.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/TestUtility.java
@@ -88,7 +88,12 @@ public class TestUtility {
                         "123456",
                         "pem-key"
                 ),
-                getRateLimitingProperties()
+                getRateLimitingProperties(),
+                new GithubProperties.Parsing(
+                        new GithubProperties.Parsing.SelfHostedRunnerOsKeywords(
+                                "", "", "vmapple"
+                        )
+                )
         );
     }
 
@@ -101,7 +106,12 @@ public class TestUtility {
                         "123456",
                         validPemKey()
                 ),
-                getRateLimitingProperties()
+                getRateLimitingProperties(),
+                new GithubProperties.Parsing(
+                        new GithubProperties.Parsing.SelfHostedRunnerOsKeywords(
+                                "", "", "vmapple"
+                        )
+                )
         );
     }
 

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/config/GithubPropertiesTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/config/GithubPropertiesTest.java
@@ -1,0 +1,41 @@
+package be.xplore.githubmetrics.githubadapter.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GithubPropertiesTest {
+
+    private GithubProperties.Parsing.SelfHostedRunnerOsKeywords osKeywords;
+
+    @BeforeEach
+    void setUp() {
+        this.osKeywords = new GithubProperties.Parsing.SelfHostedRunnerOsKeywords(
+                "somestring,someotherString",
+                " ",
+                "value"
+        );
+    }
+
+    @Test
+    void commaSeparatedListShouldBeSplitCorrectly() {
+        List<String> keywords = osKeywords.linuxKeywords();
+
+        assertEquals(List.of("somestring", "someotherstring", "linux"), keywords);
+    }
+
+    @Test
+    void blankStringShouldStillOnlyTranslateToDefaultValue() {
+        List<String> keywords = osKeywords.windowsKeywords();
+        assertEquals(List.of("windows"), keywords);
+    }
+
+    @Test
+    void singleValueShouldBeAddedCorrectly() {
+        List<String> keywords = osKeywords.macosKeywords();
+        assertEquals(List.of("value", "macos"), keywords);
+    }
+}

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunnerTest.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/mappingclasses/GHSelfHostedRunnerTest.java
@@ -1,6 +1,9 @@
 package be.xplore.githubmetrics.githubadapter.mappingclasses;
 
+import be.xplore.githubmetrics.domain.selfhostedrunner.OperatingSystem;
 import be.xplore.githubmetrics.domain.selfhostedrunner.SelfHostedRunnerStatus;
+import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,13 +13,21 @@ class GHSelfHostedRunnerTest {
     private static final String LINUX = "linux";
     private static final String ONLINE = "online";
     private static final String OFFLINE = "offline";
+    private GithubProperties.Parsing.SelfHostedRunnerOsKeywords keywords;
+
+    @BeforeEach
+    void setUp() {
+        this.keywords = new GithubProperties.Parsing.SelfHostedRunnerOsKeywords(
+                "", "", "vmapple"
+        );
+    }
 
     @Test
     void onlineAndBusyShouldLeadToBusyRunner() {
         var ghRunner = new GHSelfHostedRunner(LINUX, ONLINE, true);
         assertEquals(
                 SelfHostedRunnerStatus.BUSY,
-                ghRunner.getRunner().getSelfHostedRunnerStatus()
+                ghRunner.getRunner(this.keywords).getSelfHostedRunnerStatus()
         );
     }
 
@@ -25,7 +36,7 @@ class GHSelfHostedRunnerTest {
         var ghRunner = new GHSelfHostedRunner(LINUX, ONLINE, false);
         assertEquals(
                 SelfHostedRunnerStatus.IDLE,
-                ghRunner.getRunner().getSelfHostedRunnerStatus()
+                ghRunner.getRunner(this.keywords).getSelfHostedRunnerStatus()
         );
     }
 
@@ -35,11 +46,11 @@ class GHSelfHostedRunnerTest {
         var ghRunner2 = new GHSelfHostedRunner(LINUX, OFFLINE, true);
         assertEquals(
                 SelfHostedRunnerStatus.OFFLINE,
-                ghRunner1.getRunner().getSelfHostedRunnerStatus()
+                ghRunner1.getRunner(this.keywords).getSelfHostedRunnerStatus()
         );
         assertEquals(
                 SelfHostedRunnerStatus.OFFLINE,
-                ghRunner2.getRunner().getSelfHostedRunnerStatus()
+                ghRunner2.getRunner(this.keywords).getSelfHostedRunnerStatus()
         );
     }
 
@@ -48,9 +59,9 @@ class GHSelfHostedRunnerTest {
         var ghRunner1 = new GHSelfHostedRunner(
                 "unkown operating system", OFFLINE, false
         );
-        assertThrows(
-                IllegalStateException.class,
-                ghRunner1::getRunner
+        assertEquals(
+                OperatingSystem.UNKNOWN,
+                ghRunner1.getRunner(this.keywords).getOperatingSystem()
         );
     }
 
@@ -61,7 +72,7 @@ class GHSelfHostedRunnerTest {
         );
         assertThrows(
                 IllegalStateException.class,
-                ghRunner1::getRunner
+                () -> ghRunner1.getRunner(this.keywords)
         );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,11 @@ app:
             warning_limit: ${APP_GITHUB_RATELIMITING_WARNING_LIMIT:0.9}
             concerning_limit: ${APP_GITHUB_RATELIMITING_CONCERNING_LIMIT:0.7}
             good_limit: ${APP_GITHUB_RATELIMITING_GOOD_LIMIT:0.5}
+        parsing:
+            selfhosted_runner_os_keywords:
+                linux: ${APP_GITHUB_LINUX_SELFHOSTED_RUNNER_OS_KEYWORDS:}
+                windows: ${APP_GITHUB_WINDOWS_SELFHOSTED_RUNNER_OS_KEYWORDS:}
+                macos: ${APP_GITHUB_MACOS_SELFHOSTED_RUNNER_OS_KEYWORDS:vmapple}
 togglz:
     feature-enums: be.xplore.githubmetrics.prometheusexporter.features.Features
     features:

--- a/src/test/java/be/xplore/githubmetrics/IntegrationTests.java
+++ b/src/test/java/be/xplore/githubmetrics/IntegrationTests.java
@@ -42,8 +42,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 )
 class IntegrationTests {
     private static final Logger LOGGER = LoggerFactory.getLogger(IntegrationTests.class);
+    private static final String ACTUATOR_ENDPOINT = "/actuator/prometheus";
     private static WireMockServer wireMockServer;
-    private final String actuatorEndpoint = "/actuator/prometheus";
     @Value("classpath:__files/PullRequestsValidData.json")
     private Resource pullRequestJson;
     @Autowired
@@ -172,7 +172,7 @@ class IntegrationTests {
     void retrieveAndExportRepositoriesShouldCorrectlyDisplayOnActuatorEndpoint() throws Exception {
         this.repositoryCountExporter.run();
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr("repositories_count{organization=\"github-insights\"} 1.0"));
     }
 
@@ -181,7 +181,7 @@ class IntegrationTests {
         this.pullRequestExporter.run();
 
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr("pull_requests_count_of_last_2_days{organization=\"github-insights\",state=\"OPEN\"} 1.0"));
     }
 
@@ -190,7 +190,7 @@ class IntegrationTests {
         this.jobsLabelCountsOfLastDayExporter.run();
 
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr("workflow_run_jobs{conclusion=\"SUCCESS\",organization=\"github-insights\",status=\"DONE\"} 2.0"));
     }
 
@@ -199,7 +199,7 @@ class IntegrationTests {
         this.workflowRunStatusCountsOfLastDayExporter.run();
 
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(
                 content().string(Matchers.containsString("workflow_runs{organization=\"github-insights\",status=\"DONE\"} 2.0"))
         );
@@ -210,10 +210,10 @@ class IntegrationTests {
         this.activeWorkflowRunStatusCountsExporter.run();
 
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr("active_workflow_runs{organization=\"github-insights\",status=\"IN_PROGRESS\"} 1.0"));
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr("active_workflow_runs{organization=\"github-insights\",status=\"PENDING\"} 1.0"));
     }
 
@@ -222,12 +222,12 @@ class IntegrationTests {
         this.workflowRunBuildTimesOfLastDayExporter.run();
 
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr(
                 "workflow_runs_total_build_times{organization=\"github-insights\",status=\"DONE\"} 272000.0"
         ));
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr(
                 "workflow_runs_average_build_times{organization=\"github-insights\",status=\"DONE\"} 136000.0"
         ));
@@ -237,21 +237,21 @@ class IntegrationTests {
     void retrieveAndExportSelfHostedRunnersShouldCorrectlyDisplayStatusesAndOss() throws Exception {
         this.selfHostedRunnerCountsExporter.run();
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr("self_hosted_runners{organization=\"github-insights\",os=\"LINUX\",status=\"BUSY\"} 1.0"));
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr("self_hosted_runners{organization=\"github-insights\",os=\"WINDOWS\",status=\"OFFLINE\"} 1.0"));
         mockMvc.perform(MockMvcRequestBuilders
-                .get(actuatorEndpoint)
+                .get(ACTUATOR_ENDPOINT)
         ).andExpect(containsStr("self_hosted_runners{organization=\"github-insights\",os=\"MAC_OS\",status=\"IDLE\"} 1.0"));
     }
 
     @Test
-    void retriveAndExportApiRateLimitStateShouldCorrecltyExportData() throws Exception {
+    void retrieveAndExportApiRateLimitStateShouldCorrectlyExportData() throws Exception {
         this.apiRateLimitStateExporter.run();
         mockMvc.perform(MockMvcRequestBuilders
-                        .get(actuatorEndpoint)
+                        .get(ACTUATOR_ENDPOINT)
                 )
                 .andExpect(containsStr("api_ratelimit_state_actual_req{organization=\"github-insights\"} 0.0"))
                 .andExpect(containsStr("api_ratelimit_state_ideal_req{organization=\"github-insights\"} 0.0"))


### PR DESCRIPTION
#166 The os string returned by the Github api turned out to be more unpredictable then expected. This meant that a more complex setup was needed to convert the os string to the `OperatingSystem` enum.

Converting the string to enum works by trying to find any of a list of value in the returned os string. This list can be extended from the `application.yaml` through the `APP_GITHUB_<OS>_SELFHOSTED_RUNNER_OS_KEYWORDS` environemnt variable.

Additionally, instead of throwing an Exception when the parsing didn't succeed I added a `UNKNOWN` variant to the enum and log the os string for later reference.