### PR TITLE
unstucking the rate limit status

### DIFF
--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubProperties.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/GithubProperties.java
@@ -24,6 +24,7 @@ public record GithubProperties(
     }
 
     public record RateLimiting(
+            String stateControlCheckSchedule,
             long secondsBetweenStateRecalculations,
             double rateLimitBuffer,
             double criticalLimit,

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitResetAwaitScheduler.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitResetAwaitScheduler.java
@@ -4,9 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.annotation.SchedulingConfigurer;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -14,7 +11,7 @@ import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 
 @Service
-public class RateLimitResetAwaitScheduler implements SchedulingConfigurer {
+public class RateLimitResetAwaitScheduler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RateLimitResetAwaitScheduler.class);
     private final TaskScheduler taskScheduler;
@@ -24,14 +21,6 @@ public class RateLimitResetAwaitScheduler implements SchedulingConfigurer {
             @Qualifier("githubAdapterTaskScheduler") TaskScheduler taskScheduler
     ) {
         this.taskScheduler = taskScheduler;
-    }
-
-    @Override
-    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
-        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
-        threadPoolTaskScheduler.setPoolSize(1);
-        threadPoolTaskScheduler.setThreadNamePrefix("rate-limit-reset-await-scheduler");
-        threadPoolTaskScheduler.initialize();
     }
 
     public void createStopAllRequestsTask(

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitStateControlScheduler.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitStateControlScheduler.java
@@ -1,0 +1,44 @@
+package be.xplore.githubmetrics.githubadapter.config.ratelimiting;
+
+import be.xplore.githubmetrics.domain.apistate.ApiRateLimitState;
+import be.xplore.githubmetrics.githubadapter.config.GithubProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RateLimitStateControlScheduler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RateLimitStateControlScheduler.class);
+    private final ApiRateLimitState rateLimitState;
+    private long lastRemainingRequests;
+
+    public RateLimitStateControlScheduler(
+            GithubProperties githubProperties,
+            @Qualifier("githubAdapterTaskScheduler") TaskScheduler taskScheduler,
+            ApiRateLimitState rateLimitState
+    ) {
+        this.rateLimitState = rateLimitState;
+        this.lastRemainingRequests = rateLimitState.getRemaining();
+
+        String controlSchedule = githubProperties.ratelimiting().stateControlCheckSchedule();
+
+        LOGGER.error("Rate-limit state control scheduler is on schedule {}.", controlSchedule);
+
+        taskScheduler.schedule(
+                this::controlApiRateLimitState,
+                triggerContext -> new CronTrigger(controlSchedule)
+                        .nextExecution(triggerContext)
+        );
+    }
+
+    private void controlApiRateLimitState() {
+        if (this.rateLimitState.getUsed() == this.lastRemainingRequests) {
+            this.rateLimitState.lowerStatusByOne();
+        }
+        this.lastRemainingRequests = rateLimitState.getUsed();
+    }
+}

--- a/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/TestUtility.java
+++ b/github-adapter/src/test/java/be/xplore/githubmetrics/githubadapter/TestUtility.java
@@ -117,7 +117,7 @@ public class TestUtility {
 
     public static GithubProperties.RateLimiting getRateLimitingProperties() {
         return new GithubProperties.RateLimiting(
-                60, 0.9, 1.2, 0.9, 0.7, 0.5
+                "0 */5 * * * ?", 60, 0.9, 1.2, 0.9, 0.7, 0.5
         );
     }
 

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/features/FeaturesAspect.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/features/FeaturesAspect.java
@@ -22,7 +22,7 @@ public class FeaturesAspect {
         if (featureAssociation.value().isActive()) {
             return joinPoint.proceed();
         } else {
-            LOGGER.info("Feature {} is not enabled!", featureAssociation.value().name());
+            LOGGER.debug("Feature {} is not enabled!", featureAssociation.value().name());
             return null;
         }
     }

--- a/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/MetricSchedulerTest.java
+++ b/prometheus-exporter/src/test/java/be/xplore/githubmetrics/prometheusexporter/MetricSchedulerTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
-import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
@@ -30,7 +29,6 @@ class MetricSchedulerTest {
         when(this.mockExporter.cronExpression()).thenReturn(CRON_EXP);
 
         this.metricScheduler = new MetricScheduler(this.mockScheduler, List.of(this.mockExporter));
-        this.metricScheduler.configureTasks(mock(ScheduledTaskRegistrar.class));
     }
 
     @Test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,6 @@ logging:
     level:
         be.xplore.githubmetrics:
             ROOT: ${LOGGING_LEVEL:INFO}
-            githubadapter.config: TRACE
-
 management:
     endpoints:
         web:
@@ -60,6 +58,7 @@ app:
         url: https://api.github.com
         org: "github-insights"
         ratelimiting:
+            state_control_check_schedule: ${APP_GITHUB_RATELIMITING_STATE_CONTROL_CHECK_SCHEDULE:0 */5 * * * ?}
             seconds_between_state_recalculations: ${APP_GITHUB_RATELIMITING_SECONDS_BETWEEN_STATE_RECALCULATIONS:60}
             rate_limit_buffer: ${APP_GHITHUB_RATELIMIT_BUFFER:0.9}
             critical_limit: ${APP_GITHUB_RATELIMITING_CRITICAL_LIMIT:1.2}


### PR DESCRIPTION
#170 Before the problem was that the status could only update when requests where beeing made meaning that in the case where all requests were stopped because the status changed to CRITICAL for example it would never update.

Now I have created a control task that runs every so often (default 5 mins) and checks if requests have been made in that timeframe. If that is not the case then it lowers the status by one. (Consider that since the status is an optional and empty in the case of a limit await this lowering by one might actually not do anything)