### PR TITLE
fixed startup cost

### DIFF
--- a/domain/src/main/java/be/xplore/githubmetrics/domain/apistate/GetCurrentApiRateLimitStateUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/apistate/GetCurrentApiRateLimitStateUseCase.java
@@ -1,10 +1,13 @@
 package be.xplore.githubmetrics.domain.apistate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetCurrentApiRateLimitStateUseCase {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetCurrentApiRateLimitStateUseCase.class);
     private final ApiRateLimitStateQueryPort apiRateLimitStateQueryPort;
 
     public GetCurrentApiRateLimitStateUseCase(
@@ -14,6 +17,7 @@ public class GetCurrentApiRateLimitStateUseCase {
     }
 
     public ApiRateLimitState getCurrentApiRateLimitState() {
+        LOGGER.debug("Exporting current Api rate limit state");
         return this.apiRateLimitStateQueryPort.getCurrentApiRateLimitState();
     }
 }

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/job/GetAllJobsOfLastDayUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/job/GetAllJobsOfLastDayUseCase.java
@@ -25,7 +25,7 @@ public class GetAllJobsOfLastDayUseCase {
     public List<Job> getAllJobsOfLastDay() {
         List<WorkflowRun> workflowRuns
                 = getAllWorkflowRunsOfLastDayUseCase.getAllWorkflowRunsOfLastDay();
-        LOGGER.info("Exporting Jobs of {} workflow runs.", workflowRuns.size());
+        LOGGER.debug("Exporting Jobs of {} workflow runs.", workflowRuns.size());
         return workflowRuns.stream().map(
                 jobsQuery::getAllJobsForWorkflowRun
         ).flatMap(List::stream).toList();

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/pullrequest/GetAllPullRequestsUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/pullrequest/GetAllPullRequestsUseCase.java
@@ -25,7 +25,7 @@ public class GetAllPullRequestsUseCase {
 
     public List<PullRequest> getAllPullRequests() {
         List<Repository> repositories = repositoriesQuery.getAllRepositories();
-        LOGGER.info("Exporting pull requests for {} repositories.", repositories.size());
+        LOGGER.debug("Exporting pull requests for {} repositories.", repositories.size());
         return repositories.stream().map(
                 pullRequestQuery::getAllPullRequestsForRepository
         ).flatMap(List::stream).toList();

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/repository/GetAllRepositoriesUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/repository/GetAllRepositoriesUseCase.java
@@ -17,7 +17,7 @@ public class GetAllRepositoriesUseCase {
     }
 
     public List<Repository> getAllRepositories() {
-        LOGGER.info("Exporting all available Repositories.");
+        LOGGER.debug("Exporting all available Repositories.");
         return this.repositoriesQueryPort.getAllRepositories();
     }
 }

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/GetAllSelfHostedRunnersUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/selfhostedrunner/GetAllSelfHostedRunnersUseCase.java
@@ -24,7 +24,7 @@ public class GetAllSelfHostedRunnersUseCase {
 
     public List<SelfHostedRunner> getAllSelfHostedRunners() {
         var repositories = this.repositoriesQuery.getAllRepositories();
-        LOGGER.info(
+        LOGGER.debug(
                 "Exporting self hosted runners for organization and {} repositories",
                 repositories.size()
         );

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/workflowrun/GetActiveWorkflowRunsUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/workflowrun/GetActiveWorkflowRunsUseCase.java
@@ -2,6 +2,8 @@ package be.xplore.githubmetrics.domain.workflowrun;
 
 import be.xplore.githubmetrics.domain.repository.RepositoriesQueryPort;
 import be.xplore.githubmetrics.domain.repository.Repository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -9,6 +11,7 @@ import java.util.List;
 @Component
 public class GetActiveWorkflowRunsUseCase {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetActiveWorkflowRunsUseCase.class);
     private final RepositoriesQueryPort repositoriesQuery;
     private final ActiveWorkflowRunsQueryPort activeWorkflowRunsQuery;
 
@@ -22,6 +25,10 @@ public class GetActiveWorkflowRunsUseCase {
 
     public List<WorkflowRun> getActiveWorkflowRuns() {
         List<Repository> repositories = repositoriesQuery.getAllRepositories();
+        LOGGER.debug(
+                "Exporting active workflow runs for {} repositories.",
+                repositories.size()
+        );
         return repositories.stream().map(
                 activeWorkflowRunsQuery::getActiveWorkflowRuns
         ).flatMap(List::stream).toList();

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/workflowrun/GetAllWorkflowRunBuildTimesOfLastDayUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/workflowrun/GetAllWorkflowRunBuildTimesOfLastDayUseCase.java
@@ -24,7 +24,7 @@ public class GetAllWorkflowRunBuildTimesOfLastDayUseCase {
     public List<WorkflowRun> getAllWorkflowRunBuildTime() {
         List<WorkflowRun> workflowRuns
                 = getAllWorkflowRunsOfLastDayUseCase.getAllWorkflowRunsOfLastDay();
-        LOGGER.info("Exporting build times for {} workflow runs.", workflowRuns.size());
+        LOGGER.debug("Exporting build times for {} workflow runs.", workflowRuns.size());
         workflowRuns.forEach(workflowRun ->
                 workflowRun.setBuildTime(
                         workflowRunBuildTimesQueryPort.getWorkflowRunBuildTimes(workflowRun)

--- a/domain/src/main/java/be/xplore/githubmetrics/domain/workflowrun/GetAllWorkflowRunsOfLastDayUseCase.java
+++ b/domain/src/main/java/be/xplore/githubmetrics/domain/workflowrun/GetAllWorkflowRunsOfLastDayUseCase.java
@@ -24,7 +24,7 @@ public class GetAllWorkflowRunsOfLastDayUseCase {
 
     public List<WorkflowRun> getAllWorkflowRunsOfLastDay() {
         List<Repository> repositories = repositoriesQuery.getAllRepositories();
-        LOGGER.info(
+        LOGGER.debug(
                 "Exporting workflow runs of last day for {} repositories.",
                 repositories.size()
         );

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/cacheevicting/EvictionScheduler.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/cacheevicting/EvictionScheduler.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
@@ -48,12 +47,14 @@ public class EvictionScheduler {
         var name = port.cacheName();
 
         if (!port.freshDataCanWait()) {
-            LOGGER.debug("Evicting {}", name);
             Optional.ofNullable(
                     this.cacheManager.getCache(name)
-            ).ifPresent(Cache::clear);
+            ).ifPresent(cache -> {
+                LOGGER.info("Evicting the cache with name: {}", name);
+                cache.clear();
+            });
         } else {
-            LOGGER.debug("Did not evict {}", name);
+            LOGGER.info("Did not evict the cache with name: {}", name);
         }
     }
 

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitStateControlScheduler.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitStateControlScheduler.java
@@ -26,7 +26,7 @@ public class RateLimitStateControlScheduler {
 
         String controlSchedule = githubProperties.ratelimiting().stateControlCheckSchedule();
 
-        LOGGER.error("Rate-limit state control scheduler is on schedule {}.", controlSchedule);
+        LOGGER.info("Rate-limit state control scheduler is on schedule {}.", controlSchedule);
 
         taskScheduler.schedule(
                 this::controlApiRateLimitState,
@@ -36,9 +36,19 @@ public class RateLimitStateControlScheduler {
     }
 
     private void controlApiRateLimitState() {
+        LOGGER.info(
+                "Rate limit control scheduler ran with previous used {} and current used {}.",
+                this.lastRemainingRequests,
+                this.rateLimitState.getUsed()
+        );
         if (this.rateLimitState.getUsed() == this.lastRemainingRequests) {
+            var previousStatus = this.rateLimitState.getStatus();
             this.rateLimitState.lowerStatusByOne();
+            LOGGER.debug(
+                    "Since previous used and current used are not equal status will be lowered from {} to {}.",
+                    previousStatus, this.rateLimitState.getStatus()
+            );
         }
-        this.lastRemainingRequests = rateLimitState.getUsed();
+        this.lastRemainingRequests = this.rateLimitState.getUsed();
     }
 }

--- a/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitingInterceptor.java
+++ b/github-adapter/src/main/java/be/xplore/githubmetrics/githubadapter/config/ratelimiting/RateLimitingInterceptor.java
@@ -195,7 +195,7 @@ public class RateLimitingInterceptor implements ClientHttpRequestInterceptor {
     }
 
     private void logRateLimitStateBefore() {
-        LOGGER.info("State before is {}", this.rateLimitState.getStatus());
+        LOGGER.debug("State before is {}", this.rateLimitState.getStatus());
         LOGGER.trace(
                 "Rate limit used requests was {} and now is {}",
                 usedRequestsAtCountingStart.get(), this.rateLimitState.getUsed()
@@ -218,6 +218,6 @@ public class RateLimitingInterceptor implements ClientHttpRequestInterceptor {
                 "Remaining minutes until limit reset {}",
                 ChronoUnit.MINUTES.between(now(), this.rateLimitState.getReset(now().getOffset()))
         );
-        LOGGER.info("State after is {}", this.rateLimitState.getStatus());
+        LOGGER.debug("State after is {}", this.rateLimitState.getStatus());
     }
 }

--- a/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/features/Features.java
+++ b/prometheus-exporter/src/main/java/be/xplore/githubmetrics/prometheusexporter/features/Features.java
@@ -1,9 +1,12 @@
 package be.xplore.githubmetrics.prometheusexporter.features;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.togglz.core.Feature;
 import org.togglz.core.context.FeatureContext;
 
 public enum Features implements Feature {
+
 
     EXPORTER_JOBS_FEATURE,
     EXPORTER_WORKFLOW_RUNS_FEATURE,
@@ -12,6 +15,12 @@ public enum Features implements Feature {
     EXPORTER_SELF_HOSTED_RUNNERS_FEATURE,
     EXPORTER_REPOSITORIES_FEATURE,
     EXPORTER_PULL_REQUESTS_FEATURE;
+
+    private final Logger logger = LoggerFactory.getLogger(Features.class);
+
+    Features() {
+        logger.info("Feature {} is active.", this);
+    }
 
     @Override
     public boolean isActive() {


### PR DESCRIPTION
#174 Before when big spikes of requests would happen the ratelimiter would raise the level so high that nothing would run anymore and then slowly drop it back down where it would then jump back up. This would take quite a while to stabilize until all the caches were up to date and the requests would diminish.

Now the ratelimiter only raises the level by one at a time makeing it less sensitive to very short and sudden spikes in requests.

Also changed some logging to have a clearer view into what is happening.